### PR TITLE
Verbessere Hinweis zu Komponenten-Abhängigkeiten und Ergebnissen

### DIFF
--- a/docs/erp_fhirversion_changes.adoc
+++ b/docs/erp_fhirversion_changes.adoc
@@ -49,7 +49,7 @@ Um die Umbenennung von Profilen oder deren Umlagerung in neue Profile festzuhalt
 
 == Generierte Vergleichs Ergebnisse
 NOTE: Die Artefakte der jeweils abhängigen Pakete wurden nicht erzeugt und werden hier nicht zur Verfügung gestellt. Diese Abhängigkeiten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden.
-Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
+Zum Beispiel können Sie die Abhängigkeiten des E-Rezept-Workflows Paketes unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
 
 Die Ergebnisse des Abgleichs der betroffenen Pakete (ohne deren direkte und indirekte Abhängigkeiten) können hier eingesehen werden:
 

--- a/docs/erp_fhirversion_changes.adoc
+++ b/docs/erp_fhirversion_changes.adoc
@@ -11,8 +11,6 @@
 :toclevels: 3
 :toc-title: Inhaltsverzeichnis
 
-toc::[]
-
 == Methodik
 Um Änderungen der FHIR Ressourcen nach Versionsübergängen zu ermitteln und zu visualisieren, bietet der HAPI Validator eine hilfreiche Funktionalität. link:https://confluence.hl7.org/pages/viewpage.action?pageId=35718580#UsingtheFHIRValidator-ComparingProfiles[Der Hapi Validator kann Profile miteinander vergleichen].
 
@@ -50,7 +48,8 @@ Um die Umbenennung von Profilen oder deren Umlagerung in neue Profile festzuhalt
 * xref:./resources/transitionfiles/transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json[transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json]
 
 == Generierte Vergleichs Ergebnisse
-NOTE: Die Abhängigkeiten der vorgestellten Komponenten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden. Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
+NOTE: Die Artefakte der jeweils abhängigen Pakete wurden nicht erzeigt und werden hier nicht zur Verdügung gestellt. Diese Abhängigkeiten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden.
+Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
 
 Die Ergebnisse des Abgleichs der betroffenen Pakete (ohne deren direkte und indirekte Abhängigkeiten) können hier eingesehen werden:
 

--- a/docs/erp_fhirversion_changes.adoc
+++ b/docs/erp_fhirversion_changes.adoc
@@ -48,7 +48,7 @@ Um die Umbenennung von Profilen oder deren Umlagerung in neue Profile festzuhalt
 * xref:./resources/transitionfiles/transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json[transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json]
 
 == Generierte Vergleichs Ergebnisse
-NOTE: Die Artefakte der jeweils abhängigen Pakete wurden nicht erzeigt und werden hier nicht zur Verdügung gestellt. Diese Abhängigkeiten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden.
+NOTE: Die Artefakte der jeweils abhängigen Pakete wurden nicht erzeugt und werden hier nicht zur Verfügung gestellt. Diese Abhängigkeiten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden.
 Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
 
 Die Ergebnisse des Abgleichs der betroffenen Pakete (ohne deren direkte und indirekte Abhängigkeiten) können hier eingesehen werden:

--- a/docs/erp_fhirversion_changes.adoc
+++ b/docs/erp_fhirversion_changes.adoc
@@ -50,7 +50,9 @@ Um die Umbenennung von Profilen oder deren Umlagerung in neue Profile festzuhalt
 * xref:./resources/transitionfiles/transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json[transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json]
 
 == Generierte Vergleichs Ergebnisse
-Die Ergebnisse der Abgleiche können hier eingesehen werden:
+NOTE: Die Abhängigkeiten der vorgestellten Komponenten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden. Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
+
+Die Ergebnisse des Abgleichs der betroffenen Pakete (ohne deren direkte und indirekte Abhängigkeiten) können hier eingesehen werden:
 
 
 * link:https://htmlpreview.github.io/?https://github.com/gematik/api-erp/blob/master/docs/resources/compare_results/de.abda.eRezeptAbgabedaten/index.html[de.abda.eRezeptAbgabedaten]

--- a/resources/docs/erp_fhirversion_changes-source.adoc
+++ b/resources/docs/erp_fhirversion_changes-source.adoc
@@ -1,5 +1,15 @@
 = E-Rezept FHIR-Package Änderungen bei Versionsübergängen image:gematik_logo.png[width=150, float="right"]
-include::./config-source.adoc[]
+// asciidoc settings for DE (German)
+// ==================================
+:imagesdir: ../images
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+:toc: macro
+:toclevels: 3
+:toc-title: Inhaltsverzeichnis
 
 toc::[]
 
@@ -40,7 +50,9 @@ Um die Umbenennung von Profilen oder deren Umlagerung in neue Profile festzuhalt
 * xref:./resources/transitionfiles/transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json[transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json]
 
 == Generierte Vergleichs Ergebnisse
-Die Ergebnisse der Abgleiche können hier eingesehen werden:
+NOTE: Die Abhängigkeiten der vorgestellten Komponenten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden. Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
+
+Die Ergebnisse des Abgleichs der betroffenen Pakete (ohne deren direkte und indirekte Abhängigkeiten) können hier eingesehen werden:
 
 
 * link:https://htmlpreview.github.io/?https://github.com/gematik/api-erp/blob/master/docs/resources/compare_results/de.abda.eRezeptAbgabedaten/index.html[de.abda.eRezeptAbgabedaten]

--- a/resources/docs/erp_fhirversion_changes-source.adoc
+++ b/resources/docs/erp_fhirversion_changes-source.adoc
@@ -1,17 +1,5 @@
 = E-Rezept FHIR-Package Änderungen bei Versionsübergängen image:gematik_logo.png[width=150, float="right"]
-// asciidoc settings for DE (German)
-// ==================================
-:imagesdir: ../images
-:tip-caption: :bulb:
-:note-caption: :information_source:
-:important-caption: :heavy_exclamation_mark:
-:caution-caption: :fire:
-:warning-caption: :warning:
-:toc: macro
-:toclevels: 3
-:toc-title: Inhaltsverzeichnis
-
-toc::[]
+include::./config-source.adoc[]
 
 == Methodik
 Um Änderungen der FHIR Ressourcen nach Versionsübergängen zu ermitteln und zu visualisieren, bietet der HAPI Validator eine hilfreiche Funktionalität. link:https://confluence.hl7.org/pages/viewpage.action?pageId=35718580#UsingtheFHIRValidator-ComparingProfiles[Der Hapi Validator kann Profile miteinander vergleichen].
@@ -50,7 +38,8 @@ Um die Umbenennung von Profilen oder deren Umlagerung in neue Profile festzuhalt
 * xref:./resources/transitionfiles/transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json[transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json]
 
 == Generierte Vergleichs Ergebnisse
-NOTE: Die Abhängigkeiten der vorgestellten Komponenten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden. Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
+NOTE: Die Artefakte der jeweils abhängigen Pakete wurden nicht erzeigt und werden hier nicht zur Verdügung gestellt. Diese Abhängigkeiten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden.
+Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
 
 Die Ergebnisse des Abgleichs der betroffenen Pakete (ohne deren direkte und indirekte Abhängigkeiten) können hier eingesehen werden:
 

--- a/resources/docs/erp_fhirversion_changes-source.adoc
+++ b/resources/docs/erp_fhirversion_changes-source.adoc
@@ -38,7 +38,7 @@ Um die Umbenennung von Profilen oder deren Umlagerung in neue Profile festzuhalt
 * xref:./resources/transitionfiles/transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json[transitionfile_de.gkvsv.eRezeptAbrechnungsdaten_v1.2.0_to_v1.3.0.json]
 
 == Generierte Vergleichs Ergebnisse
-NOTE: Die Artefakte der jeweils abhängigen Pakete wurden nicht erzeigt und werden hier nicht zur Verdügung gestellt. Diese Abhängigkeiten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden.
+NOTE: Die Artefakte der jeweils abhängigen Pakete wurden nicht erzeugt und werden hier nicht zur Verfügung gestellt. Diese Abhängigkeiten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden.
 Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
 
 Die Ergebnisse des Abgleichs der betroffenen Pakete (ohne deren direkte und indirekte Abhängigkeiten) können hier eingesehen werden:

--- a/resources/docs/erp_fhirversion_changes-source.adoc
+++ b/resources/docs/erp_fhirversion_changes-source.adoc
@@ -39,7 +39,7 @@ Um die Umbenennung von Profilen oder deren Umlagerung in neue Profile festzuhalt
 
 == Generierte Vergleichs Ergebnisse
 NOTE: Die Artefakte der jeweils abhängigen Pakete wurden nicht erzeugt und werden hier nicht zur Verfügung gestellt. Diese Abhängigkeiten können auf Simplifier unter dem Tab "Dependencies" eingesehen werden.
-Zum Beispiel können Sie die Abhängigkeiten des eRezept-Workflows unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
+Zum Beispiel können Sie die Abhängigkeiten des E-Rezept-Workflows Paketes unter https://simplifier.net/erezept-workflow/~dependencies einsehen. Für Änderungen innerhalb der Abhängigkeiten empfehlen wir Ihnen, die Releasenotes der Pakete zu analysieren. Beispielsweise finden Sie eine Liste der Releasenotes für das Paket "de.basisprofil.r4" in Version 1.3.2 unter https://simplifier.net/packages/de.basisprofil.r4/1.3.2.
 
 Die Ergebnisse des Abgleichs der betroffenen Pakete (ohne deren direkte und indirekte Abhängigkeiten) können hier eingesehen werden:
 


### PR DESCRIPTION
Die Änderung verbessert einen Hinweis, der Informationen zu den Abhängigkeiten von vorgestellten Komponenten und den Ergebnissen eines Paketvergleichs bereitstellt. Der Hinweis enthält nun spezifische Links zu Simplifier, wo die Abhängigkeiten eingesehen werden können und die Release Notes von Paketen analysiert werden können. Der Hinweis klärt außerdem, dass die Ergebnisse des Paketvergleichs sich nur auf die betroffenen Pakete beziehen und nicht auf deren direkte und indirekte Abhängigkeiten.