### PR TITLE
Inhaltliche Verbesserungen zum Versionsübergang

### DIFF
--- a/docs/authentisieren.adoc
+++ b/docs/authentisieren.adoc
@@ -15,6 +15,26 @@ Hier dokumentiert die gematik die Nutzung der Schnittstellen, um sich mit der Te
 
 toc::[]
 
+== Endpunkte des E-Rezept Fachdienstes
+Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
+
+*PU*
+
+* erp.zentral.erp.splitdns.ti-dienste.de
+* idp.zentral.erp.splitdns.ti-dienste.de
+
+*RU*
+
+* erp-ref.zentral.erp.splitdns.ti-dienste.de
+* idp-ref.zentral.erp.splitdns.ti-dienste.de
+
+*RU-DEV*
+
+* erp-dev.zentral.erp.splitdns.ti-dienste.de
+* idp-dev.zentral.erp.splitdns.ti-dienste.de
+
+Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
+
 == Http-Header in Requests an Dienste der Telematikinfrastruktur
 Zur Steuerung der Funktionsaufrufe, für Sicherheitsprüfungen und die Protokollierung sind verpflichtende http-Header in allen http-Requests an den IDP-Dienst und den E-Rezept-Fachdienst erforderlich. Da mit dem VAU-Transport ein "innerer" und ein "äußerer" http-Request an den E-Rezept-Fachdienst gesendet werden, ist auf das korrekte Setzen innen und außen zu achten. Die folgende Tabelle listet die notwendigen http-Header auf.
 

--- a/docs/erp_fhirversion.adoc
+++ b/docs/erp_fhirversion.adoc
@@ -46,7 +46,7 @@ image:puml_fhir_version_timeline.png[width=100%]
 
 == Versionsübergang 30.06.2023 -> 01.07.2023
 Details zum Versionsübergang finden Sie
-link:docs/erp_versionsuebergang.adoc[auf dieser Seite].
+link:erp_versionsuebergang.adoc[auf dieser Seite].
 
 == Versionsübergang 30.06.2022 -> 01.07.2022
 Annahmen:

--- a/docs/erp_versionsuebergang.adoc
+++ b/docs/erp_versionsuebergang.adoc
@@ -125,8 +125,16 @@ Response
 |POST /Task/<id>/$activate|verordnende LEI a|
 Request
 
+Workflow 160/169 (GKV):
+
 * Akzeptiert wird ein 2022 KBV Bundle
 * Akzeptiert wird ein 2023 KBV Bundle
+
+Workflow 200/209 (PKV):
+
+* Akzeptiert wird ein 2023 KBV Bundle
+
+WARNING: Der Fachdienst wird ab 01.07. so konfiguriert, dass Verordnungen mit dem Workflowtype 200 oder 209 (PKV Verordnungen), die mit einer KBV Verordnung der Version 1.0.2 erstellt wurden, abgewiesen werden.
 
 Response
 

--- a/docs/erp_versionsuebergang.adoc
+++ b/docs/erp_versionsuebergang.adoc
@@ -46,6 +46,12 @@ Die zu unterscheidenden Profilversionen sind wie folgt bezeichnet:
 * FHIR 2022: bis 30.06.2023 gültige Profilversionen
 * FHIR 2023: ab 01.07.2023 gültige Profilversionen
 
+
+WARNING: Der Fachdienst wird ab 01.07. so konfiguriert,
+dass Verordnungen mit dem Workflowtype 200 oder 209 (PKV Verordnungen),
+die mit einer KBV Verordnung der Version 1.0.2 erstellt wurden,
+abgewiesen werden.
+
 ==== Übersicht der FHIR-Profile
 [cols="h,a,a"]
 [%autowidth]
@@ -133,8 +139,6 @@ Workflow 160/169 (GKV):
 Workflow 200/209 (PKV):
 
 * Akzeptiert wird ein 2023 KBV Bundle
-
-WARNING: Der Fachdienst wird ab 01.07. so konfiguriert, dass Verordnungen mit dem Workflowtype 200 oder 209 (PKV Verordnungen), die mit einer KBV Verordnung der Version 1.0.2 erstellt wurden, abgewiesen werden.
 
 Response
 

--- a/docs/erp_versionsuebergang.adoc
+++ b/docs/erp_versionsuebergang.adoc
@@ -489,10 +489,6 @@ Response
 a|
 Request
 
-* <MedicationDispense> bzw. Bundle von MedicationDispense - FHIR 2022
-** enthält 2022 KBV Medication
-** enthält 2023 KBV Medication
-
 * <MedicationDispense> bzw. Bundle von MedicationDispense - FHIR 2023
 ** enthält 2022 KBV Medication
 ** enthält 2023 KBV Medication

--- a/docs_sources/authentisieren-source.adoc
+++ b/docs_sources/authentisieren-source.adoc
@@ -5,6 +5,26 @@ Hier dokumentiert die gematik die Nutzung der Schnittstellen, um sich mit der Te
 
 toc::[]
 
+== Endpunkte des E-Rezept Fachdienstes
+Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
+
+*PU*
+
+* erp.zentral.erp.splitdns.ti-dienste.de
+* idp.zentral.erp.splitdns.ti-dienste.de
+
+*RU*
+
+* erp-ref.zentral.erp.splitdns.ti-dienste.de
+* idp-ref.zentral.erp.splitdns.ti-dienste.de
+
+*RU-DEV*
+
+* erp-dev.zentral.erp.splitdns.ti-dienste.de
+* idp-dev.zentral.erp.splitdns.ti-dienste.de
+
+Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
+
 == Http-Header in Requests an Dienste der Telematikinfrastruktur
 Zur Steuerung der Funktionsaufrufe, für Sicherheitsprüfungen und die Protokollierung sind verpflichtende http-Header in allen http-Requests an den IDP-Dienst und den E-Rezept-Fachdienst erforderlich. Da mit dem VAU-Transport ein "innerer" und ein "äußerer" http-Request an den E-Rezept-Fachdienst gesendet werden, ist auf das korrekte Setzen innen und außen zu achten. Die folgende Tabelle listet die notwendigen http-Header auf.
 

--- a/docs_sources/erp_fhirversion-source.adoc
+++ b/docs_sources/erp_fhirversion-source.adoc
@@ -36,7 +36,7 @@ image:puml_fhir_version_timeline.png[width=100%]
 
 == Versionsübergang 30.06.2023 -> 01.07.2023
 Details zum Versionsübergang finden Sie
-link:docs/erp_versionsuebergang.adoc[auf dieser Seite].
+link:erp_versionsuebergang.adoc[auf dieser Seite].
 
 == Versionsübergang 30.06.2022 -> 01.07.2022
 Annahmen:

--- a/docs_sources/erp_versionsuebergang-source.adoc
+++ b/docs_sources/erp_versionsuebergang-source.adoc
@@ -36,6 +36,12 @@ Die zu unterscheidenden Profilversionen sind wie folgt bezeichnet:
 * FHIR 2022: bis 30.06.2023 gültige Profilversionen
 * FHIR 2023: ab 01.07.2023 gültige Profilversionen
 
+
+WARNING: Der Fachdienst wird ab 01.07. so konfiguriert,
+dass Verordnungen mit dem Workflowtype 200 oder 209 (PKV Verordnungen),
+die mit einer KBV Verordnung der Version 1.0.2 erstellt wurden,
+abgewiesen werden.
+
 ==== Übersicht der FHIR-Profile
 [cols="h,a,a"]
 [%autowidth]
@@ -123,8 +129,6 @@ Workflow 160/169 (GKV):
 Workflow 200/209 (PKV):
 
 * Akzeptiert wird ein 2023 KBV Bundle
-
-WARNING: Der Fachdienst wird ab 01.07. so konfiguriert, dass Verordnungen mit dem Workflowtype 200 oder 209 (PKV Verordnungen), die mit einer KBV Verordnung der Version 1.0.2 erstellt wurden, abgewiesen werden.
 
 Response
 

--- a/docs_sources/erp_versionsuebergang-source.adoc
+++ b/docs_sources/erp_versionsuebergang-source.adoc
@@ -479,10 +479,6 @@ Response
 a|
 Request
 
-* <MedicationDispense> bzw. Bundle von MedicationDispense - FHIR 2022
-** enthält 2022 KBV Medication
-** enthält 2023 KBV Medication
-
 * <MedicationDispense> bzw. Bundle von MedicationDispense - FHIR 2023
 ** enthält 2022 KBV Medication
 ** enthält 2023 KBV Medication

--- a/docs_sources/erp_versionsuebergang-source.adoc
+++ b/docs_sources/erp_versionsuebergang-source.adoc
@@ -115,8 +115,16 @@ Response
 |POST /Task/<id>/$activate|verordnende LEI a|
 Request
 
+Workflow 160/169 (GKV):
+
 * Akzeptiert wird ein 2022 KBV Bundle
 * Akzeptiert wird ein 2023 KBV Bundle
+
+Workflow 200/209 (PKV):
+
+* Akzeptiert wird ein 2023 KBV Bundle
+
+WARNING: Der Fachdienst wird ab 01.07. so konfiguriert, dass Verordnungen mit dem Workflowtype 200 oder 209 (PKV Verordnungen), die mit einer KBV Verordnung der Version 1.0.2 erstellt wurden, abgewiesen werden.
 
 Response
 


### PR DESCRIPTION
* Versionsnummer im Titel des Releases
* API [(1) FHIR Version Übergangszeit - B714.1 eRp FD - Confluence (gematik.de)](https://wiki.gematik.de/pages/viewpage.action?pageId=503585350)anpassen (versionsuebergang.adoc)
* PKV Verordnungen mit der 1.0.2 KBV Verordnung werden abgewiesen ab 01.07. (versionsuebergang.adoc)
* URLs des Fachdienstes angeben (s. authetifizieren.adoc)
* Link zum Versionsübergang von fhirversion.adoc gefixt