### PR TITLE
Beschreibung für Recovery Secret hinzufügen

### DIFF
--- a/docs/erp_abrufen.adoc
+++ b/docs/erp_abrufen.adoc
@@ -156,6 +156,12 @@ Content-Type: application/fhir+xml;charset=utf-8
                         <display value="Öffentliche Apotheke"/>
                     </coding>
                 </performerType>
+                <owner>
+                    <identifier>
+                        <system value="https://gematik.de/fhir/sid/telematik-id" />
+                        <value value="3-2-APO-XanthippeVeilchenblau01" />
+                    </identifier>
+                </owner>
                 <input>
                     <type>
                         <coding>
@@ -174,7 +180,7 @@ Content-Type: application/fhir+xml;charset=utf-8
     <entry>
         <resource>
             <Binary>
-                <id value="281a985c-f25b-4aae-91a6-41ad744080b0"/>
+                <id value="urn:uuid:281a985c-f25b-4aae-91a6-41ad744080b0"/>
                 <meta>
                     <versionId value="1"/>
                     <source value="#AsYRxq34dvONJAiv"/>
@@ -370,6 +376,174 @@ s|Code   s|Type Error
 |500  |Server Errors +
 [small]#Unerwarteter Serverfehler#
 |===
+
+== E-Rezept erneut abrufen
+
+Beim initialen Abrufen eines E-Rezepts erhält die Apotheke ein eindeutiges Secret, das für alle weiteren Schritte benötigt wird. Es besteht das Risiko, dass dieses Secret verloren geht. In diesem Fall kann das E-Rezept erneut abgerufen werden.
+
+Hierzu wird der Task mit den Informationen aus dem E-Rezept-Token erneut abgerufen und das Secret erneut übermittelt. Dieser Aufruf ist nur erfolgreich, wenn die gleiche Apotheke den Task erneut abruft, die das E-Rezept ursprünglich abgerufen hat.
+
+*Request*
+[cols="h,a"]
+[%autowidth]
+|===
+|URI        |https://erp.zentral.erp.splitdns.ti-dienste.de/Task/160.123.456.789.123.58?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea
+|Method     |GET
+|HTTP Header |
+----
+Content-Type: application/fhir+xml; charset=UTF-8
+Authorization: Bearer eyJraWQ.ewogImL2pA10Qql22ddtutrvx4FsDlz.rHQjEmB1lLmpqn9J
+----
+
+NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die Header `X-erp-user: l` und `X-erp-resource: Task` zu setzen.
+
+|===
+
+
+*Response*
+[source,xml]
+----
+<?xml version="1.0" encoding="utf-8"?>
+<Bundle xmlns="http://hl7.org/fhir">
+    <id value="cb8b3d4b-be1b-4934-89a4-9ac3fa9fdfa0" />
+    <type value="collection" />
+    <timestamp value="2024-02-26T05:42:19.086+00:00" />
+    <link>
+        <relation value="self" />
+        <url value="https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/160.000.226.155.301.72" />
+    </link>
+    <entry>
+        <fullUrl
+            value="https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/160.123.456.789.123.58" />
+        <resource>
+            <Task>
+                <id value="160.123.456.789.123.58" />
+                <meta>
+                    <profile
+                        value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2" />
+                </meta>
+                <extension
+                    url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
+                    <valueCoding>
+                        <system value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType" />
+                        <code value="160" />
+                        <display value="Muster 16 (Apothekenpflichtige Arzneimittel)" />
+                    </valueCoding>
+                </extension>
+                <extension
+                    url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate">
+                    <valueDate value="2020-06-02" />
+                </extension>
+                <extension
+                    url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate">
+                    <valueDate value="2020-04-01" />
+                </extension>
+                <identifier>
+                    <use value="official" />
+                    <system
+                        value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId" />
+                    <value value="160.123.456.789.123.58" />
+                </identifier>
+                <identifier>
+                    <use value="official" />
+                    <system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_Secret" />
+                    <value value="c36ca26502892b371d252c99b496e31505ff449aca9bc69e231c58148f6233cf" />
+                </identifier>
+                <status value="in-progress" />
+                <intent value="order" />
+                <for>
+                    <identifier>
+                        <system value="http://fhir.de/sid/gkv/kvid-10" />
+                        <value value="X110501499" />
+                    </identifier>
+                </for>
+                <authoredOn value="2020-03-02T08:25:05+00:00"/>
+                <lastModified value="2020-03-02T08:45:05+00:00"/>
+                <performerType>
+                    <coding>
+                        <system
+                            value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType" />
+                        <code value="urn:oid:1.2.276.0.76.4.54" />
+                        <display value="Öffentliche Apotheke" />
+                    </coding>
+                    <text value="Öffentliche Apotheke" />
+                </performerType>
+                <owner>
+                    <identifier>
+                        <system value="https://gematik.de/fhir/sid/telematik-id" />
+                        <value value="3-2-APO-XanthippeVeilchenblau01" />
+                    </identifier>
+                </owner>
+                <input>
+                    <type>
+                        <coding>
+                            <system
+                                value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType" />
+                            <code value="1" />
+                        </coding>
+                    </type>
+                    <valueReference>
+                        <reference value="a025db7a-0d00-0000-0001-000000000000" />
+                    </valueReference>
+                </input>
+            </Task>
+        </resource>
+    </entry>
+    <entry>
+        <fullUrl value="urn:uuid:281a985c-f25b-4aae-91a6-41ad744080b0" />
+        <resource>
+            <Binary>
+                <id value="281a985c-f25b-4aae-91a6-41ad744080b0" />
+                <meta>
+                    <versionId value="1" />
+                    <profile
+                        value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Binary|1.2" />
+                </meta>
+                <contentType value="application/pkcs7-mime" />
+                <data
+                    value="MIJTfQYJKoZIhvcNAQcCoIJTbjCCU2oCAQUxDzANBglghkgBZQMEAg..." />
+            </Binary>
+        </resource>
+    </entry>
+</Bundle>
+----
+
+
+[cols="a,a"]
+[%autowidth]
+|===
+s|Code   s|Type Success
+|200  | OK +
+[small]#Die Anfrage wurde erfolgreich bearbeitet. Die Response enthält die angefragten Daten.#
+s|Code   s|Type Error
+|400  | Bad Request  +
+[small]#Die Anfrage-Nachricht war fehlerhaft aufgebaut.#
+|401  |Unauthorized +
+[small]#Die Anfrage kann nicht ohne gültige Authentifizierung durchgeführt werden. Wie die Authentifizierung durchgeführt werden soll, wird im "WWW-Authenticate"-Header-Feld der Antwort übermittelt.#
+|403  |Forbidden +
+[small]#Die Anfrage wurde mangels Berechtigung des Clients nicht durchgeführt, bspw. weil der authentifizierte Benutzer nicht berechtigt ist.#
+|404  |Not found +
+[small]#Die adressierte Ressource wurde nicht gefunden, die übergebene ID ist ungültig.#
+|405 |Method Not Allowed +
+[small]#Die Anfrage darf nur mit anderen HTTP-Methoden (zum Beispiel GET statt POST) gestellt werden. Gültige Methoden für die betreffende Ressource werden im "Allow"-Header-Feld der Antwort übermittelt.#
+|408 |Request Timeout +
+[small]#Innerhalb der vom Server erlaubten Zeitspanne wurde keine vollständige Anfrage des Clients empfangen.#
+|409 |Conflict +
+[small]#Die Anfrage wurde unter falschen Annahmen gestellt. Das E-Rezept hat nicht den Status, dass es durch die Apotheke abgerufen werden kann.# +
+[small]#Im OperationOutcome werden weitere Informationen gegeben:# +
+[small]#"Task has invalid status completed"# +
+[small]#"Task has invalid status in-progress"# +
+[small]#"Task has invalid status draft"#
+|410 |Gone +
+[small]#Die angeforderte Ressource wird nicht länger bereitgestellt und wurde dauerhaft entfernt.#
+|412 |Precondition Failed +
+[small]#Die angeforderte Ressource wurde nicht von der autorisierten Organisation abgerufen.#
+|429 |Too Many Requests +
+[small]#Der Client hat zu viele Anfragen in einem bestimmten Zeitraum gesendet.#
+|500  |Server Errors +
+[small]#Unerwarteter Serverfehler#
+|===
+
 
 == Qualifizierte Signatur des E-Rezepts prüfen
 Im Apothekenverwaltungssystem liegen nach dem Abruf aus dem E-Rezept-Fachdienst der Task des Workflows und der qualifiziert signierte Verordnungsdatensatz vor. Die Rechtmäßigkeit der elektronischen Verordnung wird mittels Prüfung der QES durch den Konnektor verifiziert. Der E-Rezept-Fachdienst prüft die Signatur beim Einstellen des E-Rezepts. Die Apotheke kann sich auf diese Prüfung verlassen, hat aber auch die Möglichkeit die Signatur selbst zu prüfen. Für die Prüfung wird die soeben heruntergeladene PKCS#7-Datei in Base64-codierter Form an die SOAP-Schnittstelle der Signaturprüfung des Konnektors als http-POST-Operation geschickt.

--- a/docs/erp_abrufen.adoc
+++ b/docs/erp_abrufen.adoc
@@ -379,9 +379,11 @@ s|Code   s|Type Error
 
 == E-Rezept erneut abrufen
 
-Beim initialen Abrufen eines E-Rezepts erhält die Apotheke ein eindeutiges Secret, das für alle weiteren Schritte benötigt wird. Es besteht das Risiko, dass dieses Secret verloren geht. In diesem Fall kann das E-Rezept erneut abgerufen werden.
+Beim initialen Abrufen eines E-Rezepts erhält die Apotheke ein eindeutiges Secret, das für alle weiteren Schritte benötigt wird. Es besteht das Risiko, dass dieses Secret bei der Übertragung der Response des E-Rezept-Fachdienstes verloren geht. In diesem Fall kann das E-Rezept erneut abgerufen werden, damit die Apotheke in Besitz des Secrets kommt.
 
-Hierzu wird der Task mit den Informationen aus dem E-Rezept-Token erneut abgerufen und das Secret erneut übermittelt. Dieser Aufruf ist nur erfolgreich, wenn die gleiche Apotheke den Task erneut abruft, die das E-Rezept ursprünglich abgerufen hat.
+Hierzu wird der Task mit den Informationen aus dem E-Rezept-Token erneut abgerufen. Der E-Rezept-Fachdienst überträgt daraufhin den Task mit Secret und das QES Verordnungsbundle an die Apotheke.
+
+Dieser Aufruf ist nur erfolgreich, wenn die gleiche Apotheke den Task erneut abruft, die das E-Rezept ursprünglich abgerufen hat.
 
 *Request*
 [cols="h,a"]
@@ -410,7 +412,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
     <timestamp value="2024-02-26T05:42:19.086+00:00" />
     <link>
         <relation value="self" />
-        <url value="https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/160.000.226.155.301.72" />
+        <url value="https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/160.123.456.789.123.58" />
     </link>
     <entry>
         <fullUrl
@@ -454,7 +456,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
                 <for>
                     <identifier>
                         <system value="http://fhir.de/sid/gkv/kvid-10" />
-                        <value value="X110501499" />
+                        <value value="X123456789" />
                     </identifier>
                 </for>
                 <authoredOn value="2020-03-02T08:25:05+00:00"/>
@@ -483,7 +485,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
                         </coding>
                     </type>
                     <valueReference>
-                        <reference value="a025db7a-0d00-0000-0001-000000000000" />
+                        <reference value="281a985c-f25b-4aae-91a6-41ad744080b0" />
                     </valueReference>
                 </input>
             </Task>

--- a/docs_sources/erp_abrufen-source.adoc
+++ b/docs_sources/erp_abrufen-source.adoc
@@ -140,6 +140,72 @@ s|Code   s|Type Error
 [small]#Unerwarteter Serverfehler#
 |===
 
+== E-Rezept erneut abrufen
+
+Beim initialen Abrufen eines E-Rezepts erhält die Apotheke ein eindeutiges Secret, das für alle weiteren Schritte benötigt wird. Es besteht das Risiko, dass dieses Secret verloren geht. In diesem Fall kann das E-Rezept erneut abgerufen werden. 
+
+Hierzu wird der Task mit den Informationen aus dem E-Rezept-Token erneut abgerufen und das Secret erneut übermittelt. Dieser Aufruf ist nur erfolgreich, wenn die gleiche Apotheke den Task erneut abruft, die das E-Rezept ursprünglich abgerufen hat.
+
+*Request*
+[cols="h,a"]
+[%autowidth]
+|===
+|URI        |https://erp.zentral.erp.splitdns.ti-dienste.de/Task/160.123.456.789.123.58?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea
+|Method     |GET
+|HTTP Header |
+----
+Content-Type: application/fhir+xml; charset=UTF-8
+Authorization: Bearer eyJraWQ.ewogImL2pA10Qql22ddtutrvx4FsDlz.rHQjEmB1lLmpqn9J
+----
+
+NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die Header `X-erp-user: l` und `X-erp-resource: Task` zu setzen.
+
+|===
+
+
+*Response*
+[source,xml]
+----
+include::../resources/examples/ti-dienste/task/request_recovery_secret.xml[]
+----
+
+
+[cols="a,a"]
+[%autowidth]
+|===
+s|Code   s|Type Success
+|200  | OK +
+[small]#Die Anfrage wurde erfolgreich bearbeitet. Die Response enthält die angefragten Daten.#
+s|Code   s|Type Error
+|400  | Bad Request  +
+[small]#Die Anfrage-Nachricht war fehlerhaft aufgebaut.#
+|401  |Unauthorized +
+[small]#Die Anfrage kann nicht ohne gültige Authentifizierung durchgeführt werden. Wie die Authentifizierung durchgeführt werden soll, wird im "WWW-Authenticate"-Header-Feld der Antwort übermittelt.#
+|403  |Forbidden +
+[small]#Die Anfrage wurde mangels Berechtigung des Clients nicht durchgeführt, bspw. weil der authentifizierte Benutzer nicht berechtigt ist.#
+|404  |Not found +
+[small]#Die adressierte Ressource wurde nicht gefunden, die übergebene ID ist ungültig.#
+|405 |Method Not Allowed +
+[small]#Die Anfrage darf nur mit anderen HTTP-Methoden (zum Beispiel GET statt POST) gestellt werden. Gültige Methoden für die betreffende Ressource werden im "Allow"-Header-Feld der Antwort übermittelt.#
+|408 |Request Timeout +
+[small]#Innerhalb der vom Server erlaubten Zeitspanne wurde keine vollständige Anfrage des Clients empfangen.#
+|409 |Conflict +
+[small]#Die Anfrage wurde unter falschen Annahmen gestellt. Das E-Rezept hat nicht den Status, dass es durch die Apotheke abgerufen werden kann.# +
+[small]#Im OperationOutcome werden weitere Informationen gegeben:# +
+[small]#"Task has invalid status completed"# +
+[small]#"Task has invalid status in-progress"# +
+[small]#"Task has invalid status draft"#
+|410 |Gone +
+[small]#Die angeforderte Ressource wird nicht länger bereitgestellt und wurde dauerhaft entfernt.#
+|412 |Precondition Failed +
+[small]#Die angeforderte Ressource wurde nicht von der autorisierten Organisation abgerufen.#
+|429 |Too Many Requests +
+[small]#Der Client hat zu viele Anfragen in einem bestimmten Zeitraum gesendet.#
+|500  |Server Errors +
+[small]#Unerwarteter Serverfehler#
+|===
+
+
 == Qualifizierte Signatur des E-Rezepts prüfen
 Im Apothekenverwaltungssystem liegen nach dem Abruf aus dem E-Rezept-Fachdienst der Task des Workflows und der qualifiziert signierte Verordnungsdatensatz vor. Die Rechtmäßigkeit der elektronischen Verordnung wird mittels Prüfung der QES durch den Konnektor verifiziert. Der E-Rezept-Fachdienst prüft die Signatur beim Einstellen des E-Rezepts. Die Apotheke kann sich auf diese Prüfung verlassen, hat aber auch die Möglichkeit die Signatur selbst zu prüfen. Für die Prüfung wird die soeben heruntergeladene PKCS#7-Datei in Base64-codierter Form an die SOAP-Schnittstelle der Signaturprüfung des Konnektors als http-POST-Operation geschickt.
 

--- a/docs_sources/erp_abrufen-source.adoc
+++ b/docs_sources/erp_abrufen-source.adoc
@@ -142,9 +142,11 @@ s|Code   s|Type Error
 
 == E-Rezept erneut abrufen
 
-Beim initialen Abrufen eines E-Rezepts erhält die Apotheke ein eindeutiges Secret, das für alle weiteren Schritte benötigt wird. Es besteht das Risiko, dass dieses Secret verloren geht. In diesem Fall kann das E-Rezept erneut abgerufen werden. 
+Beim initialen Abrufen eines E-Rezepts erhält die Apotheke ein eindeutiges Secret, das für alle weiteren Schritte benötigt wird. Es besteht das Risiko, dass dieses Secret bei der Übertragung der Response des E-Rezept-Fachdienstes verloren geht. In diesem Fall kann das E-Rezept erneut abgerufen werden, damit die Apotheke in Besitz des Secrets kommt. 
 
-Hierzu wird der Task mit den Informationen aus dem E-Rezept-Token erneut abgerufen und das Secret erneut übermittelt. Dieser Aufruf ist nur erfolgreich, wenn die gleiche Apotheke den Task erneut abruft, die das E-Rezept ursprünglich abgerufen hat.
+Hierzu wird der Task mit den Informationen aus dem E-Rezept-Token erneut abgerufen. Der E-Rezept-Fachdienst überträgt daraufhin den Task mit Secret und das QES Verordnungsbundle an die Apotheke.
+
+Dieser Aufruf ist nur erfolgreich, wenn die gleiche Apotheke den Task erneut abruft, die das E-Rezept ursprünglich abgerufen hat.
 
 *Request*
 [cols="h,a"]

--- a/resources/examples/ti-dienste/task/request_recovery_secret.xml
+++ b/resources/examples/ti-dienste/task/request_recovery_secret.xml
@@ -5,7 +5,7 @@
     <timestamp value="2024-02-26T05:42:19.086+00:00" />
     <link>
         <relation value="self" />
-        <url value="https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/160.000.226.155.301.72" />
+        <url value="https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/160.123.456.789.123.58" />
     </link>
     <entry>
         <fullUrl
@@ -49,7 +49,7 @@
                 <for>
                     <identifier>
                         <system value="http://fhir.de/sid/gkv/kvid-10" />
-                        <value value="X110501499" />
+                        <value value="X123456789" />
                     </identifier>
                 </for>
                 <authoredOn value="2020-03-02T08:25:05+00:00"/>
@@ -78,7 +78,7 @@
                         </coding>
                     </type>
                     <valueReference>
-                        <reference value="a025db7a-0d00-0000-0001-000000000000" />
+                        <reference value="281a985c-f25b-4aae-91a6-41ad744080b0" />
                     </valueReference>
                 </input>
             </Task>

--- a/resources/examples/ti-dienste/task/request_recovery_secret.xml
+++ b/resources/examples/ti-dienste/task/request_recovery_secret.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Bundle xmlns="http://hl7.org/fhir">
+    <id value="cb8b3d4b-be1b-4934-89a4-9ac3fa9fdfa0" />
+    <type value="collection" />
+    <timestamp value="2024-02-26T05:42:19.086+00:00" />
+    <link>
+        <relation value="self" />
+        <url value="https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/160.000.226.155.301.72" />
+    </link>
+    <entry>
+        <fullUrl
+            value="https://erp-ref.zentral.erp.splitdns.ti-dienste.de/Task/160.123.456.789.123.58" />
+        <resource>
+            <Task>
+                <id value="160.123.456.789.123.58" />
+                <meta>
+                    <profile
+                        value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2" />
+                </meta>
+                <extension
+                    url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
+                    <valueCoding>
+                        <system value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_FlowType" />
+                        <code value="160" />
+                        <display value="Muster 16 (Apothekenpflichtige Arzneimittel)" />
+                    </valueCoding>
+                </extension>
+                <extension
+                    url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_ExpiryDate">
+                    <valueDate value="2020-06-02" />
+                </extension>
+                <extension
+                    url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_AcceptDate">
+                    <valueDate value="2020-04-01" />
+                </extension>
+                <identifier>
+                    <use value="official" />
+                    <system
+                        value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId" />
+                    <value value="160.123.456.789.123.58" />
+                </identifier>
+                <identifier>
+                    <use value="official" />
+                    <system value="https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_Secret" />
+                    <value value="c36ca26502892b371d252c99b496e31505ff449aca9bc69e231c58148f6233cf" />
+                </identifier>
+                <status value="in-progress" />
+                <intent value="order" />
+                <for>
+                    <identifier>
+                        <system value="http://fhir.de/sid/gkv/kvid-10" />
+                        <value value="X110501499" />
+                    </identifier>
+                </for>
+                <authoredOn value="2020-03-02T08:25:05+00:00"/>
+                <lastModified value="2020-03-02T08:45:05+00:00"/>
+                <performerType>
+                    <coding>
+                        <system
+                            value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_OrganizationType" />
+                        <code value="urn:oid:1.2.276.0.76.4.54" />
+                        <display value="Öffentliche Apotheke" />
+                    </coding>
+                    <text value="Öffentliche Apotheke" />
+                </performerType>
+                <owner>
+                    <identifier>
+                        <system value="https://gematik.de/fhir/sid/telematik-id" />
+                        <value value="3-2-APO-XanthippeVeilchenblau01" />
+                    </identifier>
+                </owner>
+                <input>
+                    <type>
+                        <coding>
+                            <system
+                                value="https://gematik.de/fhir/erp/CodeSystem/GEM_ERP_CS_DocumentType" />
+                            <code value="1" />
+                        </coding>
+                    </type>
+                    <valueReference>
+                        <reference value="a025db7a-0d00-0000-0001-000000000000" />
+                    </valueReference>
+                </input>
+            </Task>
+        </resource>
+    </entry>
+    <entry>
+        <fullUrl value="urn:uuid:281a985c-f25b-4aae-91a6-41ad744080b0" />
+        <resource>
+            <Binary>
+                <id value="281a985c-f25b-4aae-91a6-41ad744080b0" />
+                <meta>
+                    <versionId value="1" />
+                    <profile
+                        value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Binary|1.2" />
+                </meta>
+                <contentType value="application/pkcs7-mime" />
+                <data
+                    value="MIJTfQYJKoZIhvcNAQcCoIJTbjCCU2oCAQUxDzANBglghkgBZQMEAg..." />
+            </Binary>
+        </resource>
+    </entry>
+</Bundle>

--- a/resources/examples/ti-dienste/task/response_taskAccept.xml
+++ b/resources/examples/ti-dienste/task/response_taskAccept.xml
@@ -62,6 +62,12 @@ Content-Type: application/fhir+xml;charset=utf-8
                         <display value="Öffentliche Apotheke"/>
                     </coding>
                 </performerType>
+                <owner>
+                    <identifier>
+                        <system value="https://gematik.de/fhir/sid/telematik-id" />
+                        <value value="3-2-APO-XanthippeVeilchenblau01" />
+                    </identifier>
+                </owner>
                 <input>
                     <type>
                         <coding>
@@ -80,7 +86,7 @@ Content-Type: application/fhir+xml;charset=utf-8
     <entry>
         <resource>
             <Binary>
-                <id value="281a985c-f25b-4aae-91a6-41ad744080b0"/>
+                <id value="urn:uuid:281a985c-f25b-4aae-91a6-41ad744080b0"/>
                 <meta>
                     <versionId value="1"/>
                     <source value="#AsYRxq34dvONJAiv"/>


### PR DESCRIPTION
Mit dem Änderungseintrag C_10822 wird eine Funktion am E-Rezept-Fachdienst hinzugefügt, die es ermöglicht, dass eine Apotheke das secret erneut abrufen kann.
Diese Funktion wird Ende März '24 in der PU bereitstehen.