### PR TITLE
Den 252 Http-Statuscode zum $activate Call hinzufügen

### DIFF
--- a/docs/erp_bereitstellen.adoc
+++ b/docs/erp_bereitstellen.adoc
@@ -1230,6 +1230,8 @@ NOTE: Für den Versicherten wird eine Kopie des Bundles im JSON-Format inkl. ser
 |Code   |Type Success
 |200  | OK +
 [small]#Die Anfrage wurde erfolgreich bearbeitet und das Ergebnis der Anfrage wird in der Antwort übertragen.#
+|252  | Warning +
+[small]#Die Anfrage hat eine ungültige Arztnummer (LANR oder ZANR)#
 |Code   |Type Error
 |400  | Bad Request  +
 [small]#Die Anfrage-Nachricht war fehlerhaft aufgebaut.#

--- a/docs/erp_bereitstellen.adoc
+++ b/docs/erp_bereitstellen.adoc
@@ -1231,7 +1231,8 @@ NOTE: Für den Versicherten wird eine Kopie des Bundles im JSON-Format inkl. ser
 |200  | OK +
 [small]#Die Anfrage wurde erfolgreich bearbeitet und das Ergebnis der Anfrage wird in der Antwort übertragen.#
 |252  | Warning +
-[small]#Die Anfrage hat eine ungültige Arztnummer (LANR oder ZANR)#
+[small]#Die Anfrage hat eine ungültige Arztnummer (LANR oder ZANR): Die übergebene Arztnummer entspricht nicht den Prüfziffer-Validierungsregeln. +
+Hinweis: Es ist vorgesehen, dass zu einem späteren Zeitpunkt, die fehlerhafte Prüfziffernvalidierung zu einem Abbruch anstatt einem Warning führt.#
 |Code   |Type Error
 |400  | Bad Request  +
 [small]#Die Anfrage-Nachricht war fehlerhaft aufgebaut.#

--- a/docs/erp_statuscodes.adoc
+++ b/docs/erp_statuscodes.adoc
@@ -211,6 +211,11 @@ h|http Operation  h|Mögliche http Status Codes       h|Bedeutung/Fehlerdetails
 |GET /metadata                |200            |FHIR-CapabilityStatement erfolgreich gelesen
 |POST /Subscription           |200            |Notifications-Kanal erfolgreich aufgebaut
 
+3+h|Warnungen
+
+|POST /Task/<id>/$activate |252            |Die Anfrage hat eine ungültige Arztnummer (LANR oder ZANR): Die übergebene Arztnummer entspricht nicht den Prüfziffer-Validierungsregeln. +
+                              +
+                              *Hinweis: Es ist vorgesehen, dass zu einem späteren Zeitpunkt, die fehlerhafte Prüfziffernvalidierung zu einem Abbruch anstatt einem Warning führt.*
 3+h|Fehlerfälle
 
 .6+|GET /Task                 |400            |Ungültiger http-Request

--- a/docs_sources/erp_bereitstellen-source.adoc
+++ b/docs_sources/erp_bereitstellen-source.adoc
@@ -270,7 +270,8 @@ NOTE: Für den Versicherten wird eine Kopie des Bundles im JSON-Format inkl. ser
 |200  | OK +
 [small]#Die Anfrage wurde erfolgreich bearbeitet und das Ergebnis der Anfrage wird in der Antwort übertragen.#
 |252  | Warning +
-[small]#Die Anfrage hat eine ungültige Arztnummer (LANR oder ZANR)#
+[small]#Die Anfrage hat eine ungültige Arztnummer (LANR oder ZANR): Die übergebene Arztnummer entspricht nicht den Prüfziffer-Validierungsregeln. +
+Hinweis: Es ist vorgesehen, dass zu einem späteren Zeitpunkt, die fehlerhafte Prüfziffernvalidierung zu einem Abbruch anstatt einem Warning führt.#
 |Code   |Type Error
 |400  | Bad Request  +
 [small]#Die Anfrage-Nachricht war fehlerhaft aufgebaut.#

--- a/docs_sources/erp_bereitstellen-source.adoc
+++ b/docs_sources/erp_bereitstellen-source.adoc
@@ -269,6 +269,8 @@ NOTE: Für den Versicherten wird eine Kopie des Bundles im JSON-Format inkl. ser
 |Code   |Type Success
 |200  | OK +
 [small]#Die Anfrage wurde erfolgreich bearbeitet und das Ergebnis der Anfrage wird in der Antwort übertragen.#
+|252  | Warning +
+[small]#Die Anfrage hat eine ungültige Arztnummer (LANR oder ZANR)#
 |Code   |Type Error
 |400  | Bad Request  +
 [small]#Die Anfrage-Nachricht war fehlerhaft aufgebaut.#

--- a/docs_sources/erp_statuscodes-source.adoc
+++ b/docs_sources/erp_statuscodes-source.adoc
@@ -110,7 +110,7 @@ h|Mögliche http Status Codes  h|Bedeutung/Fehlerdetails h|Verhalten im Fehlerfa
                                      Ein Retry ist nicht zulässig.
                                      |506            |Variant Also Negotiates |
                                      Client-Failover angeraten: Ja
-                                     
+
                                      Ein Retry nur mit Client-Failover (Max. 10 Wiederholungen)
                                      |507            |Insufficient Storage |
                                      Client-Failover angeraten: Ja
@@ -177,6 +177,11 @@ h|http Operation  h|Mögliche http Status Codes       h|Bedeutung/Fehlerdetails
 |GET /metadata                |200            |FHIR-CapabilityStatement erfolgreich gelesen
 |POST /Subscription           |200            |Notifications-Kanal erfolgreich aufgebaut
 
+3+h|Warnungen
+
+|POST /Task/<id>/$activate |252            |Die Anfrage hat eine ungültige Arztnummer (LANR oder ZANR): Die übergebene Arztnummer entspricht nicht den Prüfziffer-Validierungsregeln. +
+                              +
+                              *Hinweis: Es ist vorgesehen, dass zu einem späteren Zeitpunkt, die fehlerhafte Prüfziffernvalidierung zu einem Abbruch anstatt einem Warning führt.*
 3+h|Fehlerfälle
 
 .6+|GET /Task                 |400            |Ungültiger http-Request


### PR DESCRIPTION
Den 252 Http-Statuscode zum $activate Call hinzufügen. 

Http-Statuscode 252 ist eine Warnung wegen einer ungültigen Arztnummer (LANR oder ZANR), und wurde bisher nicht dokumentiert.