### PR TITLE
Das Formatierungsproblem auf der Versicherten-Seite beheben

### DIFF
--- a/docs/erp_versicherte.adoc
+++ b/docs/erp_versicherte.adoc
@@ -1180,7 +1180,7 @@ Die Rückgabe erfolgt als `Bundle`, das ein oder mehrere MedicationDispenses ent
 [cols="h,a"]
 [%autowidth]
 |===
-|URI        |https://erp.app.ti-dienste.de/MedicationDispense?identifier=https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId|160.880.966.157.248.22
+|URI        |https://erp.app.ti-dienste.de/MedicationDispense?identifier=https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId\|160.880.966.157.248.22
 |Method     |GET
 |HTTP Header |
 ----

--- a/docs_sources/erp_versicherte-source.adoc
+++ b/docs_sources/erp_versicherte-source.adoc
@@ -404,7 +404,7 @@ Die Rückgabe erfolgt als `Bundle`, das ein oder mehrere MedicationDispenses ent
 [cols="h,a"]
 [%autowidth]
 |===
-|URI        |https://erp.app.ti-dienste.de/MedicationDispense?identifier=https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId|160.880.966.157.248.22
+|URI        |https://erp.app.ti-dienste.de/MedicationDispense?identifier=https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId\|160.880.966.157.248.22
 |Method     |GET
 |HTTP Header |
 ----


### PR DESCRIPTION
Die Tabelle unter "Mehrere Abgabeinformationen zu einem E-Rezept abrufen" auf der Versicherte Seite hatte Formatierungsprobleme. Das wird hiermit beheben