### PR TITLE
Beschreibung für TLS-Pinning von FdVs

### DIFF
--- a/docs/certificate_check.adoc
+++ b/docs/certificate_check.adoc
@@ -13,6 +13,8 @@
 
 Auf dieser Seite wird die API für E-Rezept-FdVs beschrieben, wonach diese eine Zertifikatsprüfung für gematik PKI Zertifikate durchführen müssen.
 
+NOTE: Nach Abstimmungen sind E-Rezept-FdV nach A_21218-* dazu verpflichtet ein PKI-Root Zertifikat zu pinnen. Damit muss das TLS Zertifikat nicht zusätzlich gepinnt werden. Certificate Transparency wird für das TLS Zertifikat als ausreichender Sicherheitsmechanismus bewertet, wenn ein Root Zertifikat der gematik PKI in der Anwendung gepinnt ist. Damit ist sichergestellt, dass Gesundheitsdaten des Anwenders gesichert sind. Dadurch können Clients flexibel auf einen Wechsel des TLS-Zertifikats vom E-Rezept-Fachdienst reagieren.
+
 NOTE: Es ist wichtig zu beachten, dass es zwei verschiedene Arten gibt, die PKI Zertifikate vom E-Rezept-Fachdienst zu beziehen.
 Der Bezug von Zertifikaten über `GET /CertList` ist aktuell gültig, wird aber in einem zukünftigen Release des E-Rezept-Fachdienst deprecated und durch den Abruf von Zertifikaten mittels `GET /PKICertificates` ersetzt. Zu einem späteren Zeitpunkt wird der Endpunkt entfernt.
 

--- a/docs_sources/certificate_check-source.adoc
+++ b/docs_sources/certificate_check-source.adoc
@@ -3,6 +3,8 @@ include::./config-source.adoc[]
 
 Auf dieser Seite wird die API für E-Rezept-FdVs beschrieben, wonach diese eine Zertifikatsprüfung für gematik PKI Zertifikate durchführen müssen.
 
+NOTE: Nach Abstimmungen sind E-Rezept-FdV nach A_21218-* dazu verpflichtet ein PKI-Root Zertifikat zu pinnen. Damit muss das TLS Zertifikat nicht zusätzlich gepinnt werden. Certificate Transparency wird für das TLS Zertifikat als ausreichender Sicherheitsmechanismus bewertet, wenn ein Root Zertifikat der gematik PKI in der Anwendung gepinnt ist. Damit ist sichergestellt, dass Gesundheitsdaten des Anwenders gesichert sind. Dadurch können Clients flexibel auf einen Wechsel des TLS-Zertifikats vom E-Rezept-Fachdienst reagieren.
+
 NOTE: Es ist wichtig zu beachten, dass es zwei verschiedene Arten gibt, die PKI Zertifikate vom E-Rezept-Fachdienst zu beziehen.
 Der Bezug von Zertifikaten über `GET /CertList` ist aktuell gültig, wird aber in einem zukünftigen Release des E-Rezept-Fachdienst deprecated und durch den Abruf von Zertifikaten mittels `GET /PKICertificates` ersetzt. Zu einem späteren Zeitpunkt wird der Endpunkt entfernt.
 


### PR DESCRIPTION
Nach Abstimmung mit dem BSI muss für den Austausch von Informationen mit dem E-Rezept-Fachdienst das TLS Zertifikat nicht gepinnt werden, wenn ein gematik Root Zertifikat im FdV gepinnt ist.
Eine entprechende Beschreibung wurde angefügt.