### PR TITLE
Hinzufügen der Endpunkte, die von den Apps verwendet werden

### DIFF
--- a/docs/authentisieren.adoc
+++ b/docs/authentisieren.adoc
@@ -18,7 +18,7 @@ toc::[]
 == Endpunkte des E-Rezept Fachdienstes
 Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
 
-=== Endpunkte aus der TI
+=== Endpunkte aus der TI für Primärsysteme
 
 *PU*
 
@@ -39,7 +39,7 @@ NOTE: Für die Entwicklung in der RU-DEV ist der Scope in der Anfrage-URL umzust
 
 Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
 
-=== Endpunkte aus dem Internet
+=== Endpunkte aus dem Internet für FdVs
 
 *PU*
 

--- a/docs/authentisieren.adoc
+++ b/docs/authentisieren.adoc
@@ -37,6 +37,21 @@ NOTE: Für die Entwicklung in der RU-DEV ist der Scope in der Anfrage-URL umzust
 
 Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
 
+=== Endpunkte des E-Rezept Fachdienstes der FdVs
+Für den Verbindungsaufbau aus dem Internet mit dem E-Rezept-Fachdienst stehen diese Endpunkte zur Verfügung:
+
+*PU*
+
+* erp.app.ti-dienste.de/
+
+*RU*
+
+* erp-ref.app.ti-dienste.de/
+
+*RU-DEV*
+
+* erp-dev.app.ti-dienste.de/
+
 == Http-Header in Requests an Dienste der Telematikinfrastruktur
 Zur Steuerung der Funktionsaufrufe, für Sicherheitsprüfungen und die Protokollierung sind verpflichtende http-Header in allen http-Requests an den IDP-Dienst und den E-Rezept-Fachdienst erforderlich. Da mit dem VAU-Transport ein "innerer" und ein "äußerer" http-Request an den E-Rezept-Fachdienst gesendet werden, ist auf das korrekte Setzen innen und außen zu achten. Die folgende Tabelle listet die notwendigen http-Header auf.
 

--- a/docs/authentisieren.adoc
+++ b/docs/authentisieren.adoc
@@ -18,6 +18,8 @@ toc::[]
 == Endpunkte des E-Rezept Fachdienstes
 Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
 
+=== Endpunkte aus der TI
+
 *PU*
 
 * erp.zentral.erp.splitdns.ti-dienste.de
@@ -37,20 +39,22 @@ NOTE: Für die Entwicklung in der RU-DEV ist der Scope in der Anfrage-URL umzust
 
 Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
 
-=== Endpunkte des E-Rezept Fachdienstes der FdVs
-Für den Verbindungsaufbau aus dem Internet mit dem E-Rezept-Fachdienst stehen diese Endpunkte zur Verfügung:
+=== Endpunkte aus dem Internet
 
 *PU*
 
-* erp.app.ti-dienste.de/
+* erp.app.ti-dienste.de
+* idp.app.ti-dienste.de
 
 *RU*
 
-* erp-ref.app.ti-dienste.de/
+* erp-ref.app.ti-dienste.de
+* idp-ref.app.ti-dienste.de
 
 *RU-DEV*
 
-* erp-dev.app.ti-dienste.de/
+* erp-dev.app.ti-dienste.de
+* idp-ref.app.ti-dienste.de
 
 == Http-Header in Requests an Dienste der Telematikinfrastruktur
 Zur Steuerung der Funktionsaufrufe, für Sicherheitsprüfungen und die Protokollierung sind verpflichtende http-Header in allen http-Requests an den IDP-Dienst und den E-Rezept-Fachdienst erforderlich. Da mit dem VAU-Transport ein "innerer" und ein "äußerer" http-Request an den E-Rezept-Fachdienst gesendet werden, ist auf das korrekte Setzen innen und außen zu achten. Die folgende Tabelle listet die notwendigen http-Header auf.

--- a/docs/authentisieren.adoc
+++ b/docs/authentisieren.adoc
@@ -22,17 +22,19 @@ Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpu
 |===
 |E-Rezept-Fachdienst Umgebung|aus der TI für Primärsysteme |aus dem Internet für E-Rezept-FdVs
 
-|*PU*|erp.zentral.erp.splitdns.ti-dienste.de|erp.app.ti-dienste.de
+.2+|*PU*
+|erp.zentral.erp.splitdns.ti-dienste.de
+|erp.app.ti-dienste.de
 
-| |idp.zentral.idp.splitdns.ti-dienste.de|idp.app.ti-dienste.de
+|idp.zentral.idp.splitdns.ti-dienste.de|idp.app.ti-dienste.de
 
-|*RU*|erp-ref.zentral.erp.splitdns.ti-dienste.de|erp-ref.app.ti-dienste.de
+.2+|*RU*|erp-ref.zentral.erp.splitdns.ti-dienste.de|erp-ref.app.ti-dienste.de
 
-| |idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
+|idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
 
-|*RU-DEV*|erp-dev.zentral.erp.splitdns.ti-dienste.de|erp-dev.app.ti-dienste.de
+.2+|*RU-DEV*|erp-dev.zentral.erp.splitdns.ti-dienste.de|erp-dev.app.ti-dienste.de
 
-| |idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
+|idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
 
 |===
 

--- a/docs/authentisieren.adoc
+++ b/docs/authentisieren.adoc
@@ -18,43 +18,27 @@ toc::[]
 == Endpunkte des E-Rezept Fachdienstes
 Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
 
-=== Endpunkte aus der TI für Primärsysteme
+[cols="1,1,1"]
+|===
+|E-Rezept-Fachdienst Umgebung|aus der TI für Primärsysteme |aus dem Internet für E-Rezept-FdVs
 
-*PU*
+|*PU*|erp.zentral.erp.splitdns.ti-dienste.de|erp.app.ti-dienste.de
 
-* erp.zentral.erp.splitdns.ti-dienste.de
-* idp.zentral.idp.splitdns.ti-dienste.de
+| |idp.zentral.idp.splitdns.ti-dienste.de|idp.app.ti-dienste.de
 
-*RU*
+|*RU*|erp-ref.zentral.erp.splitdns.ti-dienste.de|erp-ref.app.ti-dienste.de
 
-* erp-ref.zentral.erp.splitdns.ti-dienste.de
-* idp-ref.zentral.idp.splitdns.ti-dienste.de
+| |idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
 
-*RU-DEV*
+|*RU-DEV*|erp-dev.zentral.erp.splitdns.ti-dienste.de|erp-dev.app.ti-dienste.de
 
-* erp-dev.zentral.erp.splitdns.ti-dienste.de
-* idp-ref.zentral.idp.splitdns.ti-dienste.de
+| |idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
+
+|===
 
 NOTE: Für die Entwicklung in der RU-DEV ist der Scope in der Anfrage-URL umzustellen. Als Parameter der Anfrage ist statt `&scope=e-rezept+openid` ist `&scope=e-rezept-dev+openid` anzugeben. Siehe Schritt 37 im link:https://gematik.github.io/ref-idp-server/tokenFlowPs.html[Rbelflow für Primärsysteme^].
 
 Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
-
-=== Endpunkte aus dem Internet für FdVs
-
-*PU*
-
-* erp.app.ti-dienste.de
-* idp.app.ti-dienste.de
-
-*RU*
-
-* erp-ref.app.ti-dienste.de
-* idp-ref.app.ti-dienste.de
-
-*RU-DEV*
-
-* erp-dev.app.ti-dienste.de
-* idp-ref.app.ti-dienste.de
 
 == Http-Header in Requests an Dienste der Telematikinfrastruktur
 Zur Steuerung der Funktionsaufrufe, für Sicherheitsprüfungen und die Protokollierung sind verpflichtende http-Header in allen http-Requests an den IDP-Dienst und den E-Rezept-Fachdienst erforderlich. Da mit dem VAU-Transport ein "innerer" und ein "äußerer" http-Request an den E-Rezept-Fachdienst gesendet werden, ist auf das korrekte Setzen innen und außen zu achten. Die folgende Tabelle listet die notwendigen http-Header auf.

--- a/docs_sources/authentisieren-source.adoc
+++ b/docs_sources/authentisieren-source.adoc
@@ -5,8 +5,10 @@ Hier dokumentiert die gematik die Nutzung der Schnittstellen, um sich mit der Te
 
 toc::[]
 
-== Endpunkte des E-Rezept Fachdienstes 
+== Endpunkte des E-Rezept Fachdienstes
 Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
+
+=== Endpunkte aus der TI
 
 *PU*
 
@@ -27,20 +29,22 @@ NOTE: Für die Entwicklung in der RU-DEV ist der Scope in der Anfrage-URL umzust
 
 Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
 
-=== Endpunkte des E-Rezept Fachdienstes der FdVs
-Für den Verbindungsaufbau aus dem Internet mit dem E-Rezept-Fachdienst stehen diese Endpunkte zur Verfügung:
+=== Endpunkte aus dem Internet
 
 *PU*
 
-* erp.app.ti-dienste.de/
+* erp.app.ti-dienste.de
+* idp.app.ti-dienste.de
 
 *RU*
 
-* erp-ref.app.ti-dienste.de/
+* erp-ref.app.ti-dienste.de
+* idp-ref.app.ti-dienste.de
 
 *RU-DEV*
 
-* erp-dev.app.ti-dienste.de/
+* erp-dev.app.ti-dienste.de
+* idp-ref.app.ti-dienste.de
 
 == Http-Header in Requests an Dienste der Telematikinfrastruktur
 Zur Steuerung der Funktionsaufrufe, für Sicherheitsprüfungen und die Protokollierung sind verpflichtende http-Header in allen http-Requests an den IDP-Dienst und den E-Rezept-Fachdienst erforderlich. Da mit dem VAU-Transport ein "innerer" und ein "äußerer" http-Request an den E-Rezept-Fachdienst gesendet werden, ist auf das korrekte Setzen innen und außen zu achten. Die folgende Tabelle listet die notwendigen http-Header auf.

--- a/docs_sources/authentisieren-source.adoc
+++ b/docs_sources/authentisieren-source.adoc
@@ -12,17 +12,19 @@ Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpu
 |===
 |E-Rezept-Fachdienst Umgebung|aus der TI für Primärsysteme |aus dem Internet für E-Rezept-FdVs
 
-|*PU*|erp.zentral.erp.splitdns.ti-dienste.de|erp.app.ti-dienste.de
+.2+|*PU*
+|erp.zentral.erp.splitdns.ti-dienste.de
+|erp.app.ti-dienste.de
 
-| |idp.zentral.idp.splitdns.ti-dienste.de|idp.app.ti-dienste.de
+|idp.zentral.idp.splitdns.ti-dienste.de|idp.app.ti-dienste.de
 
-|*RU*|erp-ref.zentral.erp.splitdns.ti-dienste.de|erp-ref.app.ti-dienste.de
+.2+|*RU*|erp-ref.zentral.erp.splitdns.ti-dienste.de|erp-ref.app.ti-dienste.de
 
-| |idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
+|idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
 
-|*RU-DEV*|erp-dev.zentral.erp.splitdns.ti-dienste.de|erp-dev.app.ti-dienste.de
+.2+|*RU-DEV*|erp-dev.zentral.erp.splitdns.ti-dienste.de|erp-dev.app.ti-dienste.de
 
-| |idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
+|idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
 
 |===
 

--- a/docs_sources/authentisieren-source.adoc
+++ b/docs_sources/authentisieren-source.adoc
@@ -8,7 +8,7 @@ toc::[]
 == Endpunkte des E-Rezept Fachdienstes
 Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
 
-=== Endpunkte aus der TI
+=== Endpunkte aus der TI für Primärsysteme
 
 *PU*
 
@@ -29,7 +29,7 @@ NOTE: Für die Entwicklung in der RU-DEV ist der Scope in der Anfrage-URL umzust
 
 Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
 
-=== Endpunkte aus dem Internet
+=== Endpunkte aus dem Internet für FdVs
 
 *PU*
 

--- a/docs_sources/authentisieren-source.adoc
+++ b/docs_sources/authentisieren-source.adoc
@@ -8,43 +8,27 @@ toc::[]
 == Endpunkte des E-Rezept Fachdienstes
 Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
 
-=== Endpunkte aus der TI für Primärsysteme
+[cols="1,1,1"]
+|===
+|E-Rezept-Fachdienst Umgebung|aus der TI für Primärsysteme |aus dem Internet für E-Rezept-FdVs
 
-*PU*
+|*PU*|erp.zentral.erp.splitdns.ti-dienste.de|erp.app.ti-dienste.de
 
-* erp.zentral.erp.splitdns.ti-dienste.de
-* idp.zentral.idp.splitdns.ti-dienste.de
+| |idp.zentral.idp.splitdns.ti-dienste.de|idp.app.ti-dienste.de
 
-*RU*
+|*RU*|erp-ref.zentral.erp.splitdns.ti-dienste.de|erp-ref.app.ti-dienste.de
 
-* erp-ref.zentral.erp.splitdns.ti-dienste.de
-* idp-ref.zentral.idp.splitdns.ti-dienste.de
+| |idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
 
-*RU-DEV*
+|*RU-DEV*|erp-dev.zentral.erp.splitdns.ti-dienste.de|erp-dev.app.ti-dienste.de
 
-* erp-dev.zentral.erp.splitdns.ti-dienste.de
-* idp-ref.zentral.idp.splitdns.ti-dienste.de
+| |idp-ref.zentral.idp.splitdns.ti-dienste.de|idp-ref.app.ti-dienste.de
+
+|===
 
 NOTE: Für die Entwicklung in der RU-DEV ist der Scope in der Anfrage-URL umzustellen. Als Parameter der Anfrage ist statt `&scope=e-rezept+openid` ist `&scope=e-rezept-dev+openid` anzugeben. Siehe Schritt 37 im link:https://gematik.github.io/ref-idp-server/tokenFlowPs.html[Rbelflow für Primärsysteme^].
 
 Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
-
-=== Endpunkte aus dem Internet für FdVs
-
-*PU*
-
-* erp.app.ti-dienste.de
-* idp.app.ti-dienste.de
-
-*RU*
-
-* erp-ref.app.ti-dienste.de
-* idp-ref.app.ti-dienste.de
-
-*RU-DEV*
-
-* erp-dev.app.ti-dienste.de
-* idp-ref.app.ti-dienste.de
 
 == Http-Header in Requests an Dienste der Telematikinfrastruktur
 Zur Steuerung der Funktionsaufrufe, für Sicherheitsprüfungen und die Protokollierung sind verpflichtende http-Header in allen http-Requests an den IDP-Dienst und den E-Rezept-Fachdienst erforderlich. Da mit dem VAU-Transport ein "innerer" und ein "äußerer" http-Request an den E-Rezept-Fachdienst gesendet werden, ist auf das korrekte Setzen innen und außen zu achten. Die folgende Tabelle listet die notwendigen http-Header auf.

--- a/docs_sources/authentisieren-source.adoc
+++ b/docs_sources/authentisieren-source.adoc
@@ -5,7 +5,7 @@ Hier dokumentiert die gematik die Nutzung der Schnittstellen, um sich mit der Te
 
 toc::[]
 
-== Endpunkte des E-Rezept Fachdienstes
+== Endpunkte des E-Rezept Fachdienstes 
 Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpunkte zur verfügung, je nach Entwicklungsumgebung. Angegeben werden jeweils der Endpunkt für den Fachdienst und den IDP:
 
 *PU*
@@ -26,6 +26,21 @@ Für den Verbindungsaufbau mit dem E-Rezept Fachdienst stehen verschiedene Endpu
 NOTE: Für die Entwicklung in der RU-DEV ist der Scope in der Anfrage-URL umzustellen. Als Parameter der Anfrage ist statt `&scope=e-rezept+openid` ist `&scope=e-rezept-dev+openid` anzugeben. Siehe Schritt 37 im link:https://gematik.github.io/ref-idp-server/tokenFlowPs.html[Rbelflow für Primärsysteme^].
 
 Die jeweiligen Konfigurationen können sich je nach Entwicklungsstand unterscheiden. Aktuelle Informationen zu den jeweiligen Umgebungen finden Sie https://wiki.gematik.de/display/RUAAS/E-Rezept@RU[hier].
+
+=== Endpunkte des E-Rezept Fachdienstes der FdVs
+Für den Verbindungsaufbau aus dem Internet mit dem E-Rezept-Fachdienst stehen diese Endpunkte zur Verfügung:
+
+*PU*
+
+* erp.app.ti-dienste.de/
+
+*RU*
+
+* erp-ref.app.ti-dienste.de/
+
+*RU-DEV*
+
+* erp-dev.app.ti-dienste.de/
 
 == Http-Header in Requests an Dienste der Telematikinfrastruktur
 Zur Steuerung der Funktionsaufrufe, für Sicherheitsprüfungen und die Protokollierung sind verpflichtende http-Header in allen http-Requests an den IDP-Dienst und den E-Rezept-Fachdienst erforderlich. Da mit dem VAU-Transport ein "innerer" und ein "äußerer" http-Request an den E-Rezept-Fachdienst gesendet werden, ist auf das korrekte Setzen innen und außen zu achten. Die folgende Tabelle listet die notwendigen http-Header auf.


### PR DESCRIPTION
Die FdVs bauen eine Verbindung mit dem E-Rezept-Fachdienst von außerhalb des TI-Netzwerks auf. Dafür benutzen sie andere Endpunkte als die aus dem TI, und diese werden mit diesem PR hinzugefügt.