### PR TITLE
Entfern den Hinweis bezüglich des Medikamentenaustauschs beim Abschließen eines eRezepts

### DIFF
--- a/docs/erp_abrufen.adoc
+++ b/docs/erp_abrufen.adoc
@@ -1464,8 +1464,6 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
 
 NOTE: Mit der Übergabe der MedicationDispense signalisiert der Apotheker den Abschluss des E-Rezept-Workflows. Der Versicherte erhält Informationen über das abgegebene Medikament.
 
-NOTE: Sofern kein Austausch des verordneten Medikaments erfolgte, können die Medikations-Informationen aus dem E-Rezept übernommen werden, beim Austausch gegen ein anderes Medikament müssen hier die entsprechenden Informationen angepasst werden, ebenso etwaig abweichende Dosierinformationen.
-
 NOTE: Die Zeitangabe in `<whenHandedOver value` bezieht sich auf die Übergabe des Medikaments, wann wurde es dem Überbringer des E-Rezepts ausgehändigt.
 
 NOTE: Die Codierung der Einnahmehinweise in `<dosageInstruction>` erfolgt z.B. in Textform [morgens-mittags-abends-nachts] in boolescher Notation 1=ja, 0=nein

--- a/docs_sources/erp_abrufen-source.adoc
+++ b/docs_sources/erp_abrufen-source.adoc
@@ -419,8 +419,6 @@ include::../resources/examples/ti-dienste/task/request_taskClose.xml[]
 
 NOTE: Mit der Übergabe der MedicationDispense signalisiert der Apotheker den Abschluss des E-Rezept-Workflows. Der Versicherte erhält Informationen über das abgegebene Medikament.
 
-NOTE: Sofern kein Austausch des verordneten Medikaments erfolgte, können die Medikations-Informationen aus dem E-Rezept übernommen werden, beim Austausch gegen ein anderes Medikament müssen hier die entsprechenden Informationen angepasst werden, ebenso etwaig abweichende Dosierinformationen.
-
 NOTE: Die Zeitangabe in `<whenHandedOver value` bezieht sich auf die Übergabe des Medikaments, wann wurde es dem Überbringer des E-Rezepts ausgehändigt.
 
 NOTE: Die Codierung der Einnahmehinweise in `<dosageInstruction>` erfolgt z.B. in Textform [morgens-mittags-abends-nachts] in boolescher Notation 1=ja, 0=nein


### PR DESCRIPTION
Entfern einen Hinweis bezüglich des Medikamentenaustauschs beim Abschließen eines eRezepts. 