### PR TITLE
Beispiele auf Workflow-Paket 1.3 aktualisieren

### DIFF
--- a/docs/certificate_check.adoc
+++ b/docs/certificate_check.adoc
@@ -275,7 +275,7 @@ Content-Type: application/ocsp-response
 
 Eine Beispielhafte OCSP-Response ist unter folgendem Link zu finden:
 
-link:https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/certificate_check/04_response_ocspResponse.der[OCSP Response]
+link:https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/certificate_check/04_response_ocspResponse.der[OCSP Response]
 
 [cols="a,a"]
 [%autowidth]

--- a/docs/erp_abrufen.adoc
+++ b/docs/erp_abrufen.adoc
@@ -423,7 +423,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
                 <id value="160.123.456.789.123.58" />
                 <meta>
                     <profile
-                        value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2" />
+                        value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3" />
                 </meta>
                 <extension
                     url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
@@ -500,7 +500,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
                 <meta>
                     <versionId value="1" />
                     <profile
-                        value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Binary|1.2" />
+                        value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Binary|1.3" />
                 </meta>
                 <contentType value="application/pkcs7-mime" />
                 <data
@@ -1976,7 +1976,7 @@ HTTP/1.1 200 OK
                     <versionId value="2"/>
                     <lastUpdated value="2020-02-18T10:05:05.038+00:00"/>
                     <source value="#AsYR9plLkvONJAiv"/>
-                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2"/>
+                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"/>
                 </meta>
                 <extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
                     <valueCodeableConcept>
@@ -2049,7 +2049,7 @@ HTTP/1.1 200 OK
             <Bundle xmlns="http://hl7.org/fhir">
                 <id value="dffbfd6a-5712-4798-bdc8-07201eb77ab8"/>
                 <meta>
-                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Bundle|1.2" />
+                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Bundle|1.3" />
                     <tag>
                         <display value="ePrescription receipt" />
                     </tag>
@@ -2065,7 +2065,7 @@ HTTP/1.1 200 OK
                     <resource>
                         <Composition>
                             <meta>
-                                <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Composition|1.2" />
+                                <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Composition|1.3" />
                             </meta>
                             <extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_Beneficiary">
                                 <valueIdentifier>
@@ -2100,7 +2100,7 @@ HTTP/1.1 200 OK
                         <Device>
                             <id value="1" />
                             <meta>
-                                <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Device|1.2" />
+                                <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Device|1.3" />
                             </meta>
                             <status value="active" />
                             <serialNumber value="R4.0.0.287342834" />

--- a/docs/erp_bereitstellen.adoc
+++ b/docs/erp_bereitstellen.adoc
@@ -109,7 +109,7 @@ Content-Type: application/fhir+xml; charset=UTF-8
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-03-02T08:26:21.594+00:00"/>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2"/>
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"/>
         <source value="#AsYR9plLkvONJAiv"/>
     </meta>
     <extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
@@ -1153,7 +1153,7 @@ Content-Type: application/fhir+xml;charset=utf-8
         <versionId value="2"/>
         <lastUpdated value="2020-02-18T10:05:05.038+00:00"/>
         <source value="#AsYR9plLkvONJAiv"/>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2"/>
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"/>
     </meta>
     <extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
         <valueCodeableConcept>

--- a/docs/erp_chargeItem.adoc
+++ b/docs/erp_chargeItem.adoc
@@ -166,7 +166,7 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
       <Binary xmlns="http://hl7.org/fhir">
          <id value="Abg123"/>
          <meta>
-            <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Binary|1.2"/>
+            <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Binary|1.3"/>
          </meta>
          <contentType value="application/pkcs7-mime"/>
          <data value="MIImXAYJKoZIhvcNAQcCoIImTTCCJkkCAQExDTALBglghkgBZ..."/>
@@ -412,7 +412,7 @@ NOTE:  Mit dem ACCESS_TOKEN im `Authorization`-Header weist sich der Zugreifende
                 <meta>
                     <lastUpdated value="2023-11-21T00:10:23.724+01:00" />
                     <profile
-                        value="http://fhir.abda.de/eRezeptAbgabedaten/StructureDefinition/DAV-PKV-PR-ERP-AbgabedatenBundle|1.2" />
+                        value="http://fhir.abda.de/eRezeptAbgabedaten/StructureDefinition/DAV-PKV-PR-ERP-AbgabedatenBundle|1.3" />
                 </meta>
                 ...
             </Bundle>
@@ -925,7 +925,7 @@ NOTE: Mit dem ACCESS_TOKEN im `Authorization`-Header weist sich der Zugreifende 
         "resourceType": "Bundle",
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Bundle|1.2"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Bundle|1.3"
           ]
         }
         ...

--- a/docs/erp_communication.adoc
+++ b/docs/erp_communication.adoc
@@ -62,7 +62,7 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
   "resourceType": "Communication",
   "meta": {
     "profile": [
-      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_InfoReq|1.2"
+      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_InfoReq|1.3"
     ]
   },
   "contained": [
@@ -233,7 +233,7 @@ Content-Type: application/fhir+json;charset=utf-8
     "versionId": "1",
     "lastUpdated": "2020-03-12T18:01:10+00:00",
     "profile": [
-      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_InfoReq|1.2"
+      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_InfoReq|1.3"
     ]
   },
   "contained": [
@@ -447,7 +447,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 ----
 <Communication xmlns="http://hl7.org/fhir">
     <meta>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Reply|1.2" />
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Reply|1.3" />
     </meta>
     <basedOn>
         <reference value="Task/160.123.456.789.123.58"/>
@@ -485,7 +485,7 @@ Location:
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-03-12T18:01:10+00:00"/>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Reply|1.2" />
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Reply|1.3" />
     </meta>
     <basedOn>
         <reference value="Task/160.123.456.789.123.58" />
@@ -567,7 +567,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
   "resourceType": "Communication",
   "meta": {
     "profile":  [
-      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_DispReq|1.2"
+      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_DispReq|1.3"
     ]
   },
   "basedOn":  [{
@@ -603,7 +603,7 @@ Content-Type: application/fhir+json;charset=utf-8
     "versionId": "1",
     "lastUpdated": "2020-03-12T18:01:10+00:00",
     "profile": [
-      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_DispReq|1.2"
+      "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_DispReq|1.3"
     ]
   },
   "sent": "2020-03-12T18:01:10+00:00",
@@ -722,7 +722,7 @@ Content-Type: application/fhir+json;charset=utf-8
           "versionId": "1",
           "lastUpdated": "2020-03-12T18:15:10+00:00",
           "profile": [
-            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Reply|1.2"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Reply|1.3"
           ]
         },
         "status": "unknown",
@@ -862,7 +862,7 @@ Content-Type: application/fhir+xml;charset=utf-8
                     <versionId value="1"/>
                     <lastUpdated value="2020-04-12T18:01:10+00:00"/>
                     <source value="#H8gavJ2v535x6V3f"/>
-                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_InfoReq|1.2" />
+                    <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_InfoReq|1.3" />
                 </meta>
                 <contained>
                     <Medication>

--- a/docs/erp_steuerung_durch_le.adoc
+++ b/docs/erp_steuerung_durch_le.adoc
@@ -88,7 +88,7 @@ Content-Type: application/fhir+xml; charset=UTF-8
 <Task xmlns="http://hl7.org/fhir">
     <id value="169.000.004.839.514.95"/>
     <meta>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2"/>
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"/>
     </meta>
     <extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
         <valueCoding>
@@ -207,7 +207,7 @@ Content-Type: application/fhir+xml;charset=utf-8
 <Task xmlns="http://hl7.org/fhir">
     <id value="169.000.004.839.514.95" />
     <meta>
-        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2" />
+        <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3" />
     </meta>
     <extension url="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType">
         <valueCoding>
@@ -496,7 +496,7 @@ Content-Type: application/fhir+json;charset=utf-8
     "id": "169.774.328.939.869.74",
     "meta": {
         "profile":  [
-            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"
         ],
         "tag":  [
             {
@@ -572,7 +572,7 @@ Content-Type: application/fhir+json;charset=utf-8
     "id": "169.000.033.491.280.78",
     "meta": {
         "profile":  [
-            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"
         ]
     },
     "intent": "order",

--- a/docs/erp_versicherte.adoc
+++ b/docs/erp_versicherte.adoc
@@ -355,7 +355,7 @@ Content-Type: application/fhir+json;charset=utf-8
           "lastUpdated": "2020-02-18T10:05:05.038+00:00",
           "source": "#AsYR9plLkvONJAiv",
           "profile": [
-            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3"
           ]
         },
         "identifier": [
@@ -925,7 +925,7 @@ Content-Type: application/fhir+json;charset=utf-8
         },
         "meta": {
           "profile": [
-            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"
           ]
         },
         "contained": [
@@ -1097,7 +1097,7 @@ Content-Type: application/fhir+json;charset=utf-8
     "resourceType": "MedicationDispense",
     "meta": {
         "profile": [
-            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"
+            "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"
         ]
     },
     "contained": [
@@ -1282,7 +1282,7 @@ Content-Type: application/fhir+json;charset=utf-8
                 "id": "200.000.002.097.952.60",
                 "meta": {
                     "profile": [
-                        "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"
+                        "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"
                     ],
                     "tag": [
                         {
@@ -1407,7 +1407,7 @@ Content-Type: application/fhir+json;charset=utf-8
                 "id": "200.000.002.097.952.60-1",
                 "meta": {
                     "profile": [
-                        "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2"
+                        "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3"
                     ],
                     "tag": [
                         {
@@ -1677,7 +1677,7 @@ Content-Type: application/fhir+json;charset=utf-8
         "lastUpdated": "2020-02-27T08:04:27.434+00:00",
         "source": "#IkMt252YovlsJTAE",
         "profile": [
-          "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_AuditEvent|1.2"
+          "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_AuditEvent|1.3"
         ]
       },
       "text": {
@@ -1744,7 +1744,7 @@ Content-Type: application/fhir+json;charset=utf-8
         "lastUpdated": "2020-02-27T09:04:27.434+00:00",
         "source": "#IkMt252YovlsJTAE",
         "profile": [
-          "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_AuditEvent|1.2"
+          "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_AuditEvent|1.3"
         ]
       },
       "text": {
@@ -1811,7 +1811,7 @@ Content-Type: application/fhir+json;charset=utf-8
         "lastUpdated": "2020-02-27T10:04:27.434+00:00",
         "source": "#IkMt252YovlsJTAE",
         "profile": [
-          "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_AuditEvent|1.2"
+          "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_AuditEvent|1.3"
         ]
       },
       "text": {

--- a/docs/misc_api_endpoints.adoc
+++ b/docs/misc_api_endpoints.adoc
@@ -56,7 +56,7 @@ NOTE:  Die Base64-Darstellung des ACCESS_TOKEN im `Authorization`-Header ist sta
         <mode value="server" />
         <resource>
             <type value="Task" />
-            <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.2" />
+            <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Task|1.3" />
             <interaction>
                 <code value="create" />
             </interaction>
@@ -110,13 +110,13 @@ NOTE:  Die Base64-Darstellung des ACCESS_TOKEN im `Authorization`-Header ist sta
             <type value="Communication" />
             <profile value="http://hl7.org/fhir/StructureDefinition/Communication|4.0.1" />
             <supportedProfile
-                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_InfoReq|1.2" />
+                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_InfoReq|1.3" />
             <supportedProfile
-                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Reply|1.2" />
+                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Reply|1.3" />
             <supportedProfile
-                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_DispReq|1.2" />
+                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_DispReq|1.3" />
             <supportedProfile
-                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Representative|1.2" />
+                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Communication_Representative|1.3" />
             <supportedProfile
                 value="https://gematik.de/fhir/erpchrg/StructureDefinition/GEM_ERPCHRG_PR_Communication_ChargChangeReq|1.0" />
             <supportedProfile
@@ -150,7 +150,7 @@ NOTE:  Die Base64-Darstellung des ACCESS_TOKEN im `Authorization`-Header ist sta
         <resource>
             <type value="MedicationDispense" />
             <profile
-                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.2" />
+                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_MedicationDispense|1.3" />
             <interaction>
                 <code value="read" />
             </interaction>
@@ -170,7 +170,7 @@ NOTE:  Die Base64-Darstellung des ACCESS_TOKEN im `Authorization`-Header ist sta
         <resource>
             <type value="AuditEvent" />
             <profile
-                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_AuditEvent|1.2" />
+                value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_AuditEvent|1.3" />
             <interaction>
                 <code value="read" />
             </interaction>
@@ -185,7 +185,7 @@ NOTE:  Die Base64-Darstellung des ACCESS_TOKEN im `Authorization`-Header ist sta
         </resource>
         <resource>
             <type value="Device" />
-            <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Device|1.2" />
+            <profile value="https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_PR_Device|1.3" />
             <interaction>
                 <code value="read" />
             </interaction>

--- a/docs_sources/authentisieren-source.adoc
+++ b/docs_sources/authentisieren-source.adoc
@@ -125,7 +125,7 @@ SOAPAction: "http://ws.gematik.de/conn/CertificateService/v7.4#ReadCardCertifica
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/authentisieren/01_request_ReadCardCertificate.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/01_request_ReadCardCertificate.xml[]
 ----
 NOTE: In `<ns8:CertRef>C.AUT</ns8:CertRef>` wird angegeben, dass das Zertifikat zur Authentisierung gegenüber dem IDP aus der SMC-B ausgelesen werden soll.
 |===
@@ -133,7 +133,7 @@ NOTE: In `<ns8:CertRef>C.AUT</ns8:CertRef>` wird angegeben, dass das Zertifikat 
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/authentisieren/02_response_ReadCardCertificate.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/02_response_ReadCardCertificate.xml[]
 ----
 NOTE: Der Konnektor liefert das Zertifikat in `<ns5:X509Certificate>` zurück, wie es auf der Karte gespeichert ist, ASN.1 DER codiert in Base64-Darstellung.
 
@@ -172,7 +172,7 @@ IMPORTANT: Die Länge des Soap-Requests, muss entsprechend im Header mit der Eig
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/authentisieren/03_request_VerifyCertificate.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/03_request_VerifyCertificate.xml[]
 ----
 NOTE: Das zu prüfende Zertifikat in Base64-DER-Codierung ist mit `<m2:X509Certificate></m2:X509Certificate>` identifiziert.
 |===
@@ -182,7 +182,7 @@ NOTE: Das zu prüfende Zertifikat in Base64-DER-Codierung ist mit `<m2:X509Certi
 ----
 HTTP/1.1 200 OK
 Content-Type: text/xml;charset=utf-8
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/authentisieren/04_response_VerifyCertificate.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/04_response_VerifyCertificate.xml[]
 ----
 NOTE: In `<ns4:VerificationResult></ns4:VerificationResult>` wird das Prüfergebnis des Zertifikats [VALID = gültig, INCONCLUSIVE = offline-gültig ohne Sperrstatus, INVALID = ungültig] angegeben
 
@@ -212,7 +212,7 @@ SOAPAction: "http://ws.gematik.de/conn/SignatureService/v7.4#ExternalAuthenticat
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/authentisieren/05_request_ExternalAuthenticate.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/05_request_ExternalAuthenticate.xml[]
 ----
 NOTE: Entsprechend der Mandantenkonfiguration wird in `<ns1:CardHandle></ns1:CardHandle>` die SMC-B referenziert, welche der IDP authentifizieren soll.
 
@@ -224,7 +224,7 @@ NOTE: In `<ns7:Base64Data></ns7:Base64Data>` befindet sich der zu signierende Ha
 ----
 HTTP/1.1 200 OK
 Content-Type: text/xml;charset=utf-8
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/authentisieren/06_response_ExternalAuthenticate.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/06_response_ExternalAuthenticate.xml[]
 ----
 
 
@@ -405,7 +405,7 @@ Nach dem erfolgreichen Abschluss der Bearbeitung des Requests durch die VAU des 
 Der HTTP-Statuscode 200 signalisiert dabei die korrekte Verarbeitung und Erstellung der verschlüsselten Antwort. Die innere HTTP-Response des fachlichen Ergebnisses aus der VAU kann dabei einen abweichenden HTTP-Statuscode beinhalten, wenn aufgrund der Daten oder Verarbeitung innerhalb der VAU Fehlerzustände eintreten oder ungültige Daten übergeben wurden. Sei `001111101111100110001001001111010110010010111110101100100011110...` die verschlüsselte Response zum obigen Beispiel. Die Entschlüsselung mit dem für den Request generierten Antwortschlüssel `16bac90134c635e4ec85fae0e4885d9f`mittels AES-GCM liefert die innere HTTP-Response der VAU als leerzeichengetrennte Zeichenkette:
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/authentisieren/07_response_InnerVau.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/07_response_InnerVau.json[]
 ----
 
 NOTE: Die innere HTTP-Response hat die folgende Struktur "1" + " " + ursprüngliche-Request-ID + " " + Response-Header-und-Body

--- a/docs_sources/certificate_check-source.adoc
+++ b/docs_sources/certificate_check-source.adoc
@@ -51,7 +51,7 @@ Content-Type: application/json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/certificate_check/01_response_certList.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/certificate_check/01_response_certList.json[]
 ----
 
 
@@ -106,7 +106,7 @@ Content-Type: application/json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/certificate_check/02_response_ocspList.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/certificate_check/02_response_ocspList.json[]
 ----
 
 
@@ -173,7 +173,7 @@ Content-Type: application/json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/certificate_check/03_response_pkicertificates.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/certificate_check/03_response_pkicertificates.json[]
 ----
 
 
@@ -232,7 +232,7 @@ Content-Type: application/ocsp-response
 
 Eine Beispielhafte OCSP-Response ist unter folgendem Link zu finden:
 
-link:https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/certificate_check/04_response_ocspResponse.der[OCSP Response]
+link:https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/certificate_check/04_response_ocspResponse.der[OCSP Response]
 
 [cols="a,a"]
 [%autowidth]

--- a/docs_sources/erp_abrufen-source.adoc
+++ b/docs_sources/erp_abrufen-source.adoc
@@ -83,7 +83,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/01_response_taskAccept.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/01_response_taskAccept.xml[]
 ----
 
 Wenn ein E-Rezept vom Workflow-type 200/209 abgerufen wird, liefert der E-Rezept-Fachdienst einen Consent zurück, wenn der Versicherte die Einwilligung über die Bereitstellung der Abrechnungsinformationen im Frontend des Versicherten erteilt hat.
@@ -95,7 +95,7 @@ HTTP/1.1 200 OK
 Content-Type: application/fhir+xml;charset=utf-8
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/02_response_taskAcceptWithConsent.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/02_response_taskAcceptWithConsent.xml[]
 ----
 
 ====
@@ -169,7 +169,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/03_request_recovery_secret.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/03_request_recovery_secret.xml[]
 ----
 
 
@@ -227,7 +227,7 @@ Content-Length: 1234
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/04_request_VerifySignatureTask.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/04_request_VerifySignatureTask.xml[]
 ----
 
 NOTE: Das Element `<m2:Base64Signature></m2:Base64Signature>`enthält das Signaturelement inkl. des signierten E-Rezept-Datensatzes (CAdES-enveloping) als PKCS#7-Datei in Base64-Codierung
@@ -248,7 +248,7 @@ HTTP/1.1 200 OK
 Content-Type: text/xml;charset=utf-8
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/05_response_VerifySignatureTask.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/05_response_VerifySignatureTask.xml[]
 ----
 NOTE: Hier dargestellt ist die QES-Signaturvalidierung einer Koco-Box der durch einen Secunet-Konnektor erzeugten Signatur aus `4fe2013d-ae94-441a-a1b1-78236ae65680_S_SECUN_secu_kon_4.8.2_4.1.3_V_KOCOC_kocobox_3.6.0_2.3.24_resp.xml`. Weitere Beispiele finden sich im Unterordner der link:../samples/qes/signed[Beispiele].
 
@@ -293,7 +293,7 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
 ¦Payload    ¦
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/06_request_taskClose.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/06_request_taskClose.xml[]
 ----
 NOTE: Sofern kein Austausch des verordneten Medikaments erfolgte, können die Medikations-Informationen aus dem E-Rezept übernommen werden, beim Austausch gegen ein anderes Medikament müssen hier die entsprechenden Informationen angepasst werden, ebenso etwaig abweichende Dosierinformationen.
 
@@ -312,7 +312,7 @@ Es können auch mehrere MedicationDispenses für eine $dispense-Operation überg
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/07_request_taskCloseMultiple.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/07_request_taskCloseMultiple.xml[]
 ----
 
 ====
@@ -320,7 +320,7 @@ include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Exa
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/08_response_taskDispense.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/08_response_taskDispense.xml[]
 ----
 
 
@@ -419,7 +419,7 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
 ¦Payload    ¦
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/06_request_taskClose.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/06_request_taskClose.xml[]
 ----
 
 NOTE: Mit der Übergabe der MedicationDispense signalisiert der Apotheker den Abschluss des E-Rezept-Workflows. Der Versicherte erhält Informationen über das abgegebene Medikament.
@@ -441,7 +441,7 @@ WARNING: Der E-Rezept-Fachdienst hat ein Datenlimit von 100kb pro Request. Falls
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/07_request_taskCloseMultiple.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/07_request_taskCloseMultiple.xml[]
 ----
 
 ====
@@ -454,7 +454,7 @@ Content-Type: application/fhir+xml;charset=utf-8
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/09_response_taskClose.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/09_response_taskClose.xml[]
 ----
 NOTE: Im Ergebnis der Operation wird ein signiertes Bundle als Nachweis des ordnungsgemäßen Durchlaufs des E-Rezept-Workflows zurückgegeben.
 
@@ -649,7 +649,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen/10_response_taskGet.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen/10_response_taskGet.xml[]
 ----
 In `<resource><Bundle/></resource>` wird die Quittung wird als Objekt zusammen mit dem Task zurückgegeben
 

--- a/docs_sources/erp_abrufen_egk-source.adoc
+++ b/docs_sources/erp_abrufen_egk-source.adoc
@@ -35,7 +35,7 @@ SOAPAction: "http://ws.gematik.de/conn/EventService/v7.2#GetCards"
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen_egk/01_GetCards.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen_egk/01_GetCards.xml[]
 ----
 
 NOTE: `<CARDCMN:CtId>Terminal1</CARDCMN:CtId>` hier wird das Kartenterminal am jeweiligen Handverkaufstisch benannt, wie es in der Mandanten- und Arbeitsplatzkonfiguration im Konnektor und AVS konfiguriert ist.
@@ -45,7 +45,7 @@ NOTE: `<CARDCMN:CtId>Terminal1</CARDCMN:CtId>` hier wird das Kartenterminal am j
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen_egk/02_GetCards_Response.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen_egk/02_GetCards_Response.xml[]
 ----
 
 NOTE: Mit dem gemeldeten `<CONN:CardHandle>a5567061-f3b0-436b-b702-fbb5026aa168</CONN:CardHandle>` wird die eGK zum Auslesen der Versichertenstammdaten adressiert.
@@ -69,7 +69,7 @@ SOAPAction: "http://ws.gematik.de/conn/vsds/VSDService/v6.0#ReadVSD"
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen_egk/03_ReadVSD.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen_egk/03_ReadVSD.xml[]
 ----
 
 NOTE: Das `<ns6:EhcHandle>` benennt die Gesundheitskarte, von welcher die VSD gelesen werden sollen.
@@ -82,7 +82,7 @@ dass zwingend eine Online-Prüfung durchgeführt und im Anschluss ein Prüfungsn
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen_egk/04_ReadVSD_Response.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen_egk/04_ReadVSD_Response.xml[]
 ----
 
 CAUTION: Liefert die `<ns6:ReadVSDResponse> <ns6:VSD_Status>` einen `<ns6:Status>1</ns6:Status>` *(ungleich 0)*, konnte der Stammdatenabgleich nicht erfolgreich beendet werden. Bei dieser Rückmeldung kann durch einen erneuten Aufruf von ReadVSD versucht werden, das Problem zu beheben. Falls es dann nicht klappt, muss der Anwendungsfall abgebrochen werden
@@ -151,7 +151,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_abrufen_egk/05_Response_Task.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_abrufen_egk/05_Response_Task.xml[]
 ----
 
 NOTE: Alle gelieferten Tasks haben den Status `<status value="ready" />` und können im Folgenden durch die Apotheke einzeln abgerufen und beliefert werden.

--- a/docs_sources/erp_alternative_zuweisung-source.adoc
+++ b/docs_sources/erp_alternative_zuweisung-source.adoc
@@ -71,7 +71,7 @@ SOAPAction: "http://ws.gematik.de/conn/SignatureService/v7.4#SignDocument"
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_alternative_zuweisung/01_sign_avs_request.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_alternative_zuweisung/01_sign_avs_request.xml[]
 ----
 NOTE: Mit der Referenz `<m2:SignatureType>urn:ietf:rfc:5652</m2:SignatureType>` auf den RFC-5652 erfolgt die Erzeugung der nonQES als CMS-Signatur (CAdES).
 
@@ -85,7 +85,7 @@ NOTE: In `<ns5:Document ID="CMS-Doc1" ShortText="a CMSDocument2sign">` erfolgt d
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_alternative_zuweisung/02_sign_avs_response.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_alternative_zuweisung/02_sign_avs_response.xml[]
 ----
 NOTE: Das Ergebnis der erfolgreichen nonQES wird Base64-codiert in `<ns7:SignatureObject>` zurückgegeben. Darin enthalten ist eine PKCS#7-Datei in HEX-Codierung, die mit einem ASN1-Decoder angesehen werden kann.
 
@@ -159,7 +159,7 @@ Das APOVZD stellt jedes Zertifikat in einer eigenen FHIR-Binary-Ressource bereit
 Beispiel eines solchen Binaries:
 [[apovzd-cert-binary]]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_alternative_zuweisung/03_certificate_in_apovzd.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_alternative_zuweisung/03_certificate_in_apovzd.json[]
 ----
 
 Das Synchronisieren vom Upload-Container in das APOVZD erfolgt täglich zwischen 0 und 6 Uhr. Spätestens ab 6 Uhr ist die Änderung für das E-Rezept-FdV verfügbar.
@@ -177,7 +177,7 @@ Dem E-Rezept-FdV werden über das APOVZD die URLs innerhalb der LocationRessourc
 
 Beispiel:
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_alternative_zuweisung/04_url_in_apovzd.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_alternative_zuweisung/04_url_in_apovzd.json[]
 ----
 
 Um aus dem E-Rezept-FdV nach Apotheken zu filtern, die dieses Feature unterstützen, wird ein zusätzlicher Type DELEGATOR aus dem Codesystem http://terminology.hl7.org/CodeSystem/v3-RoleCode eingeführt.
@@ -213,7 +213,7 @@ Als Versicherter möchte ich mein Rezept an die Apotheke meiner Wahl übermittel
 Der folgende Datensatz wird erstellt:
 
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_alternative_zuweisung/05_message_from_fdv.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_alternative_zuweisung/05_message_from_fdv.json[]
 ----
 
 === Verschlüsselung des Datensatzes
@@ -239,7 +239,7 @@ Diese ASN.1-Struktur muss Base64-DER codiert im Aufruf der Verschlüsselungsoper
 Das folgende beispielhafte Kommando verschlüsselt einen Datensatz für ein ENC-Zertifikat inkl. Einbettung der unsafe-Attribute (kotlin-Code).
 
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_alternative_zuweisung/06_example_encryption.java[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_alternative_zuweisung/06_example_encryption.java[]
 ----
 
 Der erhaltene CMS-Datensatz enthält unter der genannten OID die Entschlüsselungsinformationen für den Empfänger:
@@ -259,13 +259,13 @@ Wenn das FdV eine mit dem Zertifikat der SMB-C verschlüsselte Nachricht an den 
 === Entschlüsselung der Nachricht
 Der übermittelte CMS-Datensatz enthält die notwendigen Informationen zur Lokalisierung der für die Entschlüsselung zu nutzende SMC-B. Der Datensatz kann mit der Operation `DecryptDocument` des Konnektors entschlüsselt werden.
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_alternative_zuweisung/07_decrypt_request.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_alternative_zuweisung/07_decrypt_request.xml[]
 ----
 
 Der entschlüsselte Datensatz enthält folgende Informationen:
 
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_alternative_zuweisung/05_message_from_fdv.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_alternative_zuweisung/05_message_from_fdv.json[]
 ----
 
 NOTE: "transactionID" beinhaltet die von der E-Rezept-App erzeuge UUID zur eindeutigen Identifikation der Transaktion.

--- a/docs_sources/erp_bereitstellen-source.adoc
+++ b/docs_sources/erp_bereitstellen-source.adoc
@@ -94,7 +94,7 @@ NOTE: Der  Parameter `<code value="*"/>` steuert den Typ des dem Task zugrunde l
 HTTP/1.1 201 Created
 Content-Type: application/fhir+xml; charset=UTF-8
 
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_bereitstellen/01_response_taskCreate.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_bereitstellen/01_response_taskCreate.xml[]
 ----
 
 NOTE: Der unter dem Identifier `GEM_ERP_NS_PrescriptionId` hinterlegte `<identifier><value value="*"/></identifier>` stellt die 10 Jahre lang eineindeutige Rezept-ID dar.
@@ -147,7 +147,7 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_bereitstellen/02_Prescription_bundle.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_bereitstellen/02_Prescription_bundle.xml[]
 ----
 ====
 
@@ -180,7 +180,7 @@ SOAPAction: "http://ws.gematik.de/conn/SignatureService/v7.4#SignDocument"
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_bereitstellen/03_request_SignDocument.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_bereitstellen/03_request_SignDocument.xml[]
 ----
 NOTE: Mit der Referenz `<m2:SignatureType>urn:ietf:rfc:5652</m2:SignatureType>` auf den RFC-5652 erfolgt die Erzeugung der QES als CMS-Signatur (CAdES).
 
@@ -198,7 +198,7 @@ IMPORTANT: Der Parameter `IncludeRevocationInfo = true` ist von herausragender B
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_bereitstellen/04_response_SignDocument.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_bereitstellen/04_response_SignDocument.xml[]
 ----
 NOTE: Das Ergebnis der erfolgreichen qualifizierten Signatur wird Base64-codiert in `<ns5:SignatureObject>` zurückgegeben. Darin enthalten ist eine PKCS#7-Datei in HEX-Codierung, die mit einem ASN1-Decoder angesehen werden kann.
 
@@ -258,7 +258,7 @@ NOTE: Bei dem Wert in `<Binary><data value="*"/></Binary>` handelt es sich um di
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_bereitstellen/05_response_taskActivate.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_bereitstellen/05_response_taskActivate.xml[]
 ----
 NOTE: Der E-Rezept-Fachdienst prüft die Gültigkeit der qualifizierten Signatur des übergebenen FHIR-Bundles. Bei Gültigkeit wird der Task aktiviert und die Zuordnung des Task zum Patienten auf Basis der KVNR im Task unter dem `value` von `<system value="http://fhir.de/sid/gkv/kvid-10"/>` hinterlegt.
 

--- a/docs_sources/erp_chargeItem-source.adoc
+++ b/docs_sources/erp_chargeItem-source.adoc
@@ -55,7 +55,7 @@ SOAPAction: "http://ws.gematik.de/conn/SignatureService/v7.5#SignDocument"
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/01_request_SignDocument_Abgabedaten.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/01_request_SignDocument_Abgabedaten.xml[]
 ----
 
 |===
@@ -65,7 +65,7 @@ IMPORTANT: Der Parameter `IncludeRevocationInfo` darf nur bei einer QES-Signatur
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/02_response_SignDocument_Abgabedaten.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/02_response_SignDocument_Abgabedaten.xml[]
 ----
 NOTE: Das Ergebnis der erfolgreichen Signatur wird Base64-codiert in `<ns5:SignatureObject>` zurückgegeben. Darin enthalten ist eine PKCS#7-Datei in HEX-Codierung, die mit einem ASN1-Decoder angesehen werden kann.
 
@@ -110,7 +110,7 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
 ¦Payload    ¦
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/03_POST_ChargeItem_Request.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/03_POST_ChargeItem_Request.xml[]
 ----
 NOTE: Der PKV-Abgabesatz in Binary.data ist aus Platzgründen stark gekürzt.
 
@@ -134,7 +134,7 @@ Content-Type: application/fhir+xml;charset=utf-8
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/04_POST_ChargeItem_Response.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/04_POST_ChargeItem_Response.xml[]
 ----
 |===
 
@@ -199,7 +199,7 @@ NOTE:  Mit dem ACCESS_TOKEN im `Authorization`-Header weist sich der Zugreifende
 ¦Payload ¦
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/05_GET_ChargeItem_Response.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/05_GET_ChargeItem_Response.xml[]
 ----
 NOTE: Aus Gründen der besseren Lesbarkeit ist das PKV-Abgabdedatenbundle hier nicht vollständig dargestellt und wurde mit `...` abgekürzt. Es kann aber vollständig unter https://simplifier.net/erezept-patientenrechnung/~resources?category=Example&exampletype=Bundle eingesehen werden.
 
@@ -257,7 +257,7 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
 ¦Payload    ¦
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/06_PUT_ChargeItem_Request.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/06_PUT_ChargeItem_Request.xml[]
 ----
 NOTE: In `<id value="Abg456"/>` fügt die abgebende LEI ihren geänderten Abgabedatensatz ein.
 |===
@@ -270,7 +270,7 @@ NOTE: In `<id value="Abg456"/>` fügt die abgebende LEI ihren geänderten Abgabe
 ¦Payload ¦
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/07_PUT_ChargeItem_Response.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/07_PUT_ChargeItem_Response.xml[]
 ----
 
 |===
@@ -335,7 +335,7 @@ NOTE: Mit dem ACCESS_TOKEN im `Authorization`-Header weist sich der Zugreifende 
 ¦Payload ¦
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/08_GET_ChargeItems_Response.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/08_GET_ChargeItems_Response.json[]
 ----
 
 NOTE: Die angegebenen Referenzen werden in diesem Request nicht mitgeliefert. Im folgenden Request der das Chargeitem nach der Id abfragt sind diese Informationen dagegen enthalten.
@@ -372,7 +372,7 @@ NOTE: Mit dem ACCESS_TOKEN im `Authorization`-Header weist sich der Zugreifende 
 ¦Payload ¦
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/09_GET_ChargeItem_Response.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/09_GET_ChargeItem_Response.json[]
 ----
 
 NOTE: Das `signature` Element enthält die Signatur des Bundles über alle enthaltenen Objekte als Enveloping-CAdES-Signatur in Base64-Codierung.
@@ -428,7 +428,7 @@ NOTE:  Mit dem ACCESS_TOKEN im `Authorization`-Header weist sich der Zugreifende
 ¦Payload    ¦
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/10_PATCH_ChargeItem_Request.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/10_PATCH_ChargeItem_Request.json[]
 ----
 NOTE: In `"valueString": "ChargeItem.extension('https://gematik.de/fhir/erpchrg/StructureDefinition/GEM_ERPCHRG_EX_MarkingFlag').extension('taxOffice')"` ist der Pfadanfang, an dem das zu ändernde Attribut hängt definiert.
 
@@ -444,7 +444,7 @@ NOTE: Im `"valueString": "ChargeItem.extension('https://gematik.de/fhir/erpchrg/
 ¦Payload ¦
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_chargeItem/11_PATCH_ChargeItem_Response.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_chargeItem/11_PATCH_ChargeItem_Response.json[]
 ----
 
 |===

--- a/docs_sources/erp_communication-source.adoc
+++ b/docs_sources/erp_communication-source.adoc
@@ -48,7 +48,7 @@ NOTE: In den Profilen ist unter meta.profile auch die Version mit anzugeben. (Bs
 ¦Payload    ¦
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_communication/01_request_PostPatientToPharmacy.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_communication/01_request_PostPatientToPharmacy.json[]
 ----
 NOTE: Unter `"code": "06313728"` findet sich die Pharmazentralnummer (PZN) des angefragten Medikaments.
 
@@ -65,7 +65,7 @@ HTTP/1.1 201 Created
 Content-Type: application/fhir+json;charset=utf-8
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_communication/02_response_PostPatientToPharmacy.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_communication/02_response_PostPatientToPharmacy.json[]
 ----
 NOTE: Der Server übernimmt beim Absenden der Nachricht in `"sent": "2020-03-12T18:01:10+00:00"` den Sendezeitpunkt in die Communication-Ressource.
 
@@ -123,7 +123,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 ¦Payload    ¦
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_communication/03_request_PostPharmacyToPatient.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_communication/03_request_PostPharmacyToPatient.xml[]
 ----
 NOTE: Die von der Apotheke übermittelte Antwort ist strukturiert in .payload.contentString nach gemSpec_eRp_DM abgelegt.
 
@@ -141,7 +141,7 @@ Location:
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_communication/04_response_PostPharmacyToPatient.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_communication/04_response_PostPharmacyToPatient.xml[]
 ----
 NOTE: Der Server übernimmt beim Absenden der Nachricht den Sendezeitpunkt in die Communication-Ressource ` <sent value="2020-03-12T18:01:10+00:00" />`
 
@@ -197,7 +197,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 ¦Payload    ¦
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_communication/05_request_RezeptZuweisen.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_communication/05_request_RezeptZuweisen.json[]
 ----
 NOTE: Mit der Übergabe der Referenz auf den E-Rezept-Task inkl. des `AccessCodes` in `"reference": "Task/160.123.456.789.123.58/$accept?ac=*" ` ist die Apotheke berechtigt, das E-Rezept herunterzuladen und zu beliefern.
 
@@ -210,7 +210,7 @@ Content-Type: application/fhir+json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_communication/06_response_RezeptZuweisen.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_communication/06_response_RezeptZuweisen.json[]
 ----
 WARNING: Die derzeitige Spezifikation sieht vor, dass der E-Rezept Token in `.basedOn.reference` angegeben wird. Dieser Token entspricht nicht der FHIR-Spezifikation, wodurch die FHIR-Validatoren einen Fehler werfen.
 
@@ -276,7 +276,7 @@ Content-Type: application/fhir+json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_communication/07_response_GetMessages.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_communication/07_response_GetMessages.json[]
 ----
 NOTE: Die abgerufene Nachricht enthält kein Element `received`, da die Nachricht erstmalig vom E-Rezept-Fachdienst abgerufen wurde. Dieses Attribut `received` wurde beim Abruf durch den Fachdienst auf dessen aktuelle Systemzeit in `"sent": "2020-03-12T18:01:10+00:00"` aktualisiert, sodass ein erneuter Aufruf mit dem Filter `?received=NULL` kein Ergebnis liefert, da keine neuen  bzw. ungelesenen Nachrichten vorhanden sind.
 
@@ -339,7 +339,7 @@ Content-Type: application/fhir+xml;charset=utf-8
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_communication/08_response_GetAllMessages.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_communication/08_response_GetAllMessages.xml[]
 
 ----
 NOTE: `<total value="391"/>` gibt Auskunft über die Anzahl der Ergebnis-Einträge.

--- a/docs_sources/erp_consent-source.adoc
+++ b/docs_sources/erp_consent-source.adoc
@@ -44,7 +44,7 @@ NOTE: Mit dem ACCESS_TOKEN im `Authorization`-Header weist sich der Zugreifende 
 |Payload    |
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_consent/01_request_PostConsent.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_consent/01_request_PostConsent.json[]
 ----
 |===
 
@@ -52,7 +52,7 @@ include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Exa
 *Response*
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_consent/02_response_PostConsent.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_consent/02_response_PostConsent.json[]
 ----
 
 [cols="a,a"]
@@ -104,7 +104,7 @@ NOTE: Mit dem ACCESS_TOKEN im `Authorization`-Header weist sich der Zugreifende 
 *Response*
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_consent/03_response_GetConsent.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_consent/03_response_GetConsent.json[]
 ----
 
 [cols="a,a"]

--- a/docs_sources/erp_notification_avs-source.adoc
+++ b/docs_sources/erp_notification_avs-source.adoc
@@ -30,7 +30,7 @@ Zunächst muss für die Apotheke als authentisierter Client (gültiges AccessTok
 |Request|
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_notification_avs/01_request_PostSubscriptionPseudo.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_notification_avs/01_request_PostSubscriptionPseudo.xml[]
 ----
 
 NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die Header `X-erp-user: l` und `X-erp-resource: Subscription` zu setzen.
@@ -43,7 +43,7 @@ Andere Parameter werden aktuell nicht unterstützt.
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_notification_avs/02_response_PostSubscriptionPseudo.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_notification_avs/02_response_PostSubscriptionPseudo.xml[]
 ----
 
 NOTE: In ` <id value="df694c098c2fb373524150461cfd9d23"/>` ist eine eindeutige ID (Pseudonym der Telematik-ID) hinterlegt
@@ -151,7 +151,7 @@ Empfängt das AVS nun ein `ping: df694c098c2fb373524150461cfd9d23`, liegt eine n
 == Beispielhafte Implementierung für Primärsysteme
 [source,c++]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_notification_avs/03_ping_Subscription.cpp[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_notification_avs/03_ping_Subscription.cpp[]
 ----
 
 == => Wichtige Hinweise <=

--- a/docs_sources/erp_statuscodes-source.adoc
+++ b/docs_sources/erp_statuscodes-source.adoc
@@ -18,14 +18,14 @@ Im Folgenden ein Beispiel ein OperationOutcome eines Validierungsfehlers, der vo
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_statuscodes/01_example_operationOutcome_validation.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_statuscodes/01_example_operationOutcome_validation.xml[]
 ----
 
 Dies ist ein Beispiel für eine OperationOutcome, in der ein Abruf nicht erlaubt ist, da sich der Task in einem entsprechenden Status befindet. Siehe Fehlercode 409 aus link:./erp_abrufen.adoc#e-rezept-abrufen[E-Rezept abrufen].
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_statuscodes/02_example_operationOutcome_status.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_statuscodes/02_example_operationOutcome_status.xml[]
 ----
 
 == Status Codes am Endpunkt /VAU

--- a/docs_sources/erp_steuerung_durch_le-source.adoc
+++ b/docs_sources/erp_steuerung_durch_le-source.adoc
@@ -55,7 +55,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_steuerung_durch_le/01_request_taskCreate169.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/01_request_taskCreate169.xml[]
 ----
 Der Parameter `<code value="169"/>` steuert den Typ des dem Task zugrunde liegenden Workflows. In diesem Fall obliegt die Einlösehoheit (als Zuweisung an eine bestimmte Apotheke) beim Verordnenden Leistungserbringer.
 
@@ -64,7 +64,7 @@ Der Parameter `<code value="169"/>` steuert den Typ des dem Task zugrunde liegen
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_steuerung_durch_le/02_response_taskCreate169.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/02_response_taskCreate169.xml[]
 ----
 
 NOTE: An der Stelle `<code value="169" />` hat der E-Rezept-Fachdienst den Übergabeparameter zur Konfiguration des des Workflows übernommen.
@@ -125,7 +125,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 |Payload    |
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_steuerung_durch_le/03_request_taskActivate169.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/03_request_taskActivate169.xml[]
 ----
 NOTE: Bei ` <data value="*" />` handelt es sich um die base64-codierte Repräsentation der enveloping-Signatur mit dem enthaltenen E-Rezept-Bundle. Der codierte base64-String ist hier aus Gründen der Lesbarkeit nicht vollständig dargestellt. Das vollständige Beispiel findet sich im Unterordner der link:../samples/qes/signed[Beispiele] in der Datei `4fe2013d-ae94-441a-a1b1-78236ae65680_S_SECUN_secu_kon_4.8.2_4.1.3.p7`
 
@@ -134,7 +134,7 @@ NOTE: Bei ` <data value="*" />` handelt es sich um die base64-codierte Repräsen
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_steuerung_durch_le/04_response_taskActivate169.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/04_response_taskActivate169.xml[]
 ----
 NOTE: Der E-Rezept-Fachdienst prüft die Gültigkeit der qualifizierten Signatur des übergebenen FHIR-Bundles. Bei Gültigkeit wird der Task aktiviert und die Zuordnung des Task zum Patienten auf Basis der KVNR im Task unter `<value value="X123456789"` hinterlegt.
 
@@ -214,7 +214,7 @@ Eine Nachricht dient der direkten Zuweisung eines E-Rezeptes an eine Apotheke. D
 
 [source,text]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_steuerung_durch_le/05_emailPlainZuweisungInDerApotheke.txt[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/05_emailPlainZuweisungInDerApotheke.txt[]
 ----
 NOTE: `Subject:` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
 
@@ -226,7 +226,7 @@ NOTE: Aus Gründen der Lesbarkeit wurde der angehängte Therapieplan stark mit `
 
 [source,text]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_steuerung_durch_le/06_emailPlainFreieKommunikation.txt[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/06_emailPlainFreieKommunikation.txt[]
 ----
 NOTE: `Subject` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
 
@@ -238,7 +238,7 @@ Um auf KIM-Nachrichten zu Antworten ist nach Standardprotokoll der Header "In-Re
 
 [source,text]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_steuerung_durch_le/07_emailPlainFreieKommunikation_reply.txt[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/07_emailPlainFreieKommunikation_reply.txt[]
 ----
 NOTE: `Subject` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
 
@@ -270,7 +270,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
 *Response*
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_steuerung_durch_le/08_response_taskGet169Versicherter.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/08_response_taskGet169Versicherter.json[]
 ----
 NOTE: Der Prozesstyp in `"url": "https://gematik.de/fhir/erp/StructureDefinition/GEM_ERP_EX_PrescriptionType"` referenziert die Workflow-Definition, in diesem Fall den Prozess für apothekenpflichtige Arzneimittel.
 

--- a/docs_sources/erp_versicherte-source.adoc
+++ b/docs_sources/erp_versicherte-source.adoc
@@ -50,7 +50,7 @@ HTTP/1.1 200 OK
 Content-Type: application/fhir+json;charset=utf-8
 
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_versicherte/01_response_taskGetAll.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_versicherte/01_response_taskGetAll.json[]
 ----
 NOTE: Mit dem AccessCode `"value":"777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"` wird der Zugriff für Vertreter und Apotheker gesteuert, in dem der Versicherte diesen AccessCode z.B. als QR-Code weitergibt
 
@@ -124,7 +124,7 @@ HTTP/1.1 200 OK
 Content-Type: application/fhir+json;charset=utf-8
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_versicherte/02_response_taskGetSingle.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_versicherte/02_response_taskGetSingle.json[]
 ----
 NOTE: Mit dem AccessCode in `"value":"777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"` wird der Zugriff für Vertreter und Apotheker gesteuert, in dem der Versicherte diesen AccessCode z.B. als QR-Code weitergibt.
 
@@ -249,7 +249,7 @@ Content-Type: application/fhir+json;charset=utf-8
 ====
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_versicherte/03_response_GetLocation.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_versicherte/03_response_GetLocation.json[]
 ----
 NOTE: Die Suchanfrage nach `Adler`-Apotheken liefert genau zwei Treffer.
 
@@ -309,7 +309,7 @@ Content-Type: application/fhir+json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_versicherte/04_response_getDispense.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_versicherte/04_response_getDispense.json[]
 ----
 NOTE: Der Task wird unter `"reference":"Task/160.880.966.157.248.22"` des eingelösten E-Rezepts referenziert. Über den Link können weitere Informationen wie E-Rezept-Datensatz und ggfs. die Quittung abgerufen werden.
 
@@ -371,7 +371,7 @@ Content-Type: application/fhir+json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_versicherte/05_response_get-single-medicationdispense-by-id.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_versicherte/05_response_get-single-medicationdispense-by-id.json[]
 ----
 NOTE: Der Task wird unter `"reference":"Task/160.880.966.157.248.22"` des eingelösten E-Rezepts referenziert. Über den Link können weitere Informationen wie E-Rezept-Datensatz und ggfs. die Quittung abgerufen werden.
 
@@ -428,7 +428,7 @@ Content-Type: application/fhir+json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_versicherte/06_response_get-multiple-medication-dispense.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_versicherte/06_response_get-multiple-medication-dispense.json[]
 ----
 NOTE: Der Task wird unter `"reference":"Task/160.880.966.157.248.22"` des eingelösten E-Rezepts referenziert. Über den Link können weitere Informationen wie E-Rezept-Datensatz und ggfs. die Quittung abgerufen werden.
 
@@ -549,7 +549,7 @@ Content-Type: application/fhir+json;charset=utf-8
 
 [source,json]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/erp_versicherte/07_response_getAuditEvent.json[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_versicherte/07_response_getAuditEvent.json[]
 ----
 NOTE: Beim Abrufen der Protokolleinträge erfolgt die Rückgabe als `Bundle`, in dem die Protokolleinträge mit Bezug zum authentifizierten Versicherten über dessen KVNR aufgelistet werden. In diesem vereinfachten Beispiel werden nur drei Einträge dargestellt.
 

--- a/docs_sources/misc_api_endpoints-source.adoc
+++ b/docs_sources/misc_api_endpoints-source.adoc
@@ -24,7 +24,7 @@ NOTE:  Die Base64-Darstellung des ACCESS_TOKEN im `Authorization`-Header ist sta
 *Response*
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2023-07-01/misc_api_endpoints/CapabilityStatement_RU.xml[]
+include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/misc_api_endpoints/CapabilityStatement_RU.xml[]
 ----
 
 


### PR DESCRIPTION
Die in den Docs verwendeten Beispiele wurden jetzt auf das Workflow-Paket 1.3 aktualisiert.