### PR TITLE
Rechtschreibung des FHIR-VZD-Links korrigieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ Folgende Tools können genutzt werden, um FHIR-Dokumente zwischen XML und JSON z
 
 [Hier geht es zu den Anwendungsfällen für Versicherte, um ihre E-Rezepte zu verwalten und einzulösen](docs/erp_versicherte.adoc)
 
+[Hier geht es zu den Anwendungsfällen für die Suche nach Apotheken im FHIR VZD](docs/erp_fhirvzd_usage.adoc)
+
 #### PKV Versicherte
 
 [Hier geht es zu den Anwendungsfällen für die elektronische Verwaltung der Abrechnungsinformationen](docs/erp_chargeItem.adoc)
 
 [Hier geht es zu den Anwendungsfällen für das Verwalten der Einwilligung](docs/erp_consent.adoc)
-
-[Hier geht es zu den Anwedungsfällen für die Suche nach Apotheken im FHIR VZD](docs/erp_fhirvzd_usage.adoc)
 
 ### Anwendungsfälle für den Nachrichtenaustausch zwischen Versicherten und Apotheken
 


### PR DESCRIPTION
Der Link auf der Readme-Seite hatte einen Rechtschreibfehler und wurde jetzt korrigiert.