### PR TITLE
Der DataMatrix-Notiz für MVO entfernt

### DIFF
--- a/docs/erp_versicherte_mvo.adoc
+++ b/docs/erp_versicherte_mvo.adoc
@@ -87,7 +87,7 @@ NOTE: Eine Teilverordnung kann zu Lastern der GKV abgerechnet werden, wenn es in
 
 NOTE: Eine Reihenfolge der Abgabe der einzelnen Teilverordnungen einer MVO ist bei Abgabe nicht zu beachten.
 
-WARNING: Patienten haben zu jeder Zeit die Möglichkeit, alle Teilverordnungen einer Mehrfachverordnung über die E-Rezept-App einzusehen und die Einlöseinformationen als Datamatrix oder Zuweisung an Apotheken zu teilen (und bei Bedarf zu löschen).
+WARNING: Patienten haben zu jeder Zeit die Möglichkeit, alle Teilverordnungen einer Mehrfachverordnung über die E-Rezept-App einzusehen (und bei Bedarf zu löschen).
 
 WARNING: Apotheken sind VOR dem Gültigkeitsbeginn `valuePeriod.start` nicht berechtigt, eine Teilverordnung herunterzuladen.
 

--- a/docs/erp_versicherte_mvo.adoc
+++ b/docs/erp_versicherte_mvo.adoc
@@ -87,7 +87,7 @@ NOTE: Eine Teilverordnung kann zu Lastern der GKV abgerechnet werden, wenn es in
 
 NOTE: Eine Reihenfolge der Abgabe der einzelnen Teilverordnungen einer MVO ist bei Abgabe nicht zu beachten.
 
-WARNING: Patienten haben zu jeder Zeit die Möglichkeit, alle Teilverordnungen einer Mehrfachverordnung über die E-Rezept-App einzusehen (und bei Bedarf zu löschen).
+NOTE: Patienten haben zu jeder Zeit die Möglichkeit, alle Teilverordnungen einer Mehrfachverordnung über die E-Rezept-App einzusehen (und bei Bedarf zu löschen).
 
 WARNING: Apotheken sind VOR dem Gültigkeitsbeginn `valuePeriod.start` nicht berechtigt, eine Teilverordnung herunterzuladen.
 

--- a/docs_sources/erp_versicherte_mvo-source.adoc
+++ b/docs_sources/erp_versicherte_mvo-source.adoc
@@ -77,7 +77,7 @@ NOTE: Eine Teilverordnung kann zu Lastern der GKV abgerechnet werden, wenn es in
 
 NOTE: Eine Reihenfolge der Abgabe der einzelnen Teilverordnungen einer MVO ist bei Abgabe nicht zu beachten.
 
-WARNING: Patienten haben zu jeder Zeit die Möglichkeit, alle Teilverordnungen einer Mehrfachverordnung über die E-Rezept-App einzusehen und die Einlöseinformationen als Datamatrix oder Zuweisung an Apotheken zu teilen (und bei Bedarf zu löschen).
+WARNING: Patienten haben zu jeder Zeit die Möglichkeit, alle Teilverordnungen einer Mehrfachverordnung über die E-Rezept-App einzusehen (und bei Bedarf zu löschen).
 
 WARNING: Apotheken sind VOR dem Gültigkeitsbeginn `valuePeriod.start` nicht berechtigt, eine Teilverordnung herunterzuladen.
 

--- a/docs_sources/erp_versicherte_mvo-source.adoc
+++ b/docs_sources/erp_versicherte_mvo-source.adoc
@@ -77,7 +77,7 @@ NOTE: Eine Teilverordnung kann zu Lastern der GKV abgerechnet werden, wenn es in
 
 NOTE: Eine Reihenfolge der Abgabe der einzelnen Teilverordnungen einer MVO ist bei Abgabe nicht zu beachten.
 
-WARNING: Patienten haben zu jeder Zeit die Möglichkeit, alle Teilverordnungen einer Mehrfachverordnung über die E-Rezept-App einzusehen (und bei Bedarf zu löschen).
+NOTE: Patienten haben zu jeder Zeit die Möglichkeit, alle Teilverordnungen einer Mehrfachverordnung über die E-Rezept-App einzusehen (und bei Bedarf zu löschen).
 
 WARNING: Apotheken sind VOR dem Gültigkeitsbeginn `valuePeriod.start` nicht berechtigt, eine Teilverordnung herunterzuladen.
 


### PR DESCRIPTION
Die DataMatrix-Notiz für MVO auf der Seite "Versicherte MVO" wird entfernt.