### PR TITLE
Aktualisieren das E-Rezept Patientenrechnung Package auf 1.0.4

### DIFF
--- a/docs/erp_fhirversion.adoc
+++ b/docs/erp_fhirversion.adoc
@@ -118,7 +118,7 @@ Allgemeine Änderungen
 
 * Anpassen der Abhängigkeiten zum Workflow Package
 
-|01.05.2024 |01.11.2024 |-
+|TBD |15.01.2025 |-
 
 |===
 

--- a/docs/erp_fhirversion.adoc
+++ b/docs/erp_fhirversion.adoc
@@ -114,7 +114,7 @@ Allgemeine Änderungen
 
 |15.07.2024 | 15.01.2025 |-
 
-|gematik de.gematik.erezept-patientenrechnung.r4 |link:https://simplifier.net/packages/de.gematik.erezept-patientenrechnung.r4/1.0.3[Package 1.0.3 Profile 1.0^] a|
+|gematik de.gematik.erezept-patientenrechnung.r4 |link:https://simplifier.net/packages/de.gematik.erezept-patientenrechnung.r4/1.0.4-rc2[Package 1.0.4 Profile 1.0^] a|
 
 * Anpassen der Abhängigkeiten zum Workflow Package
 

--- a/docs_sources/erp_fhirversion-source.adoc
+++ b/docs_sources/erp_fhirversion-source.adoc
@@ -103,7 +103,7 @@ Allgemeine Änderungen
 
 * Anpassen der Abhängigkeiten zum Workflow Package
 
-|01.05.2024 |01.11.2024 |-
+|TBD |15.01.2025 |-
 
 |===
 

--- a/docs_sources/erp_fhirversion-source.adoc
+++ b/docs_sources/erp_fhirversion-source.adoc
@@ -99,7 +99,7 @@ Allgemeine Änderungen
 
 |15.07.2024 | 15.01.2025 |-
 
-|gematik de.gematik.erezept-patientenrechnung.r4 |link:https://simplifier.net/packages/de.gematik.erezept-patientenrechnung.r4/1.0.3[Package 1.0.3 Profile 1.0^] a|
+|gematik de.gematik.erezept-patientenrechnung.r4 |link:https://simplifier.net/packages/de.gematik.erezept-patientenrechnung.r4/1.0.4-rc2[Package 1.0.4 Profile 1.0^] a|
 
 * Anpassen der Abhängigkeiten zum Workflow Package
 


### PR DESCRIPTION
Die erp_fhirversion Seite hatte das Package für den 15.01.2025 als 1.0.3 statt 1.0.4. Dieses PR behebt das