### PR TITLE
Aktuelisiere die IDs der Communication Beispiele

### DIFF
--- a/docs/erp_communication.adoc
+++ b/docs/erp_communication.adoc
@@ -237,7 +237,7 @@ Content-Type: application/fhir+json;charset=utf-8
 ----
 {
   "resourceType": "Communication",
-  "id": "12345",
+  "id": "66f2fd42-773b-465c-bd2c-9fbefbd2e6f4",
   "meta": {
     "versionId": "1",
     "lastUpdated": "2020-03-12T18:01:10+00:00",
@@ -497,7 +497,7 @@ Location:
 [source,xml]
 ----
 <Communication xmlns="http://hl7.org/fhir">
-    <id value="12346"/>
+    <id value="8f9bb3ea-3480-45ea-bb0b-ffd33c57e4af"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-03-12T18:01:10+00:00"/>
@@ -621,7 +621,7 @@ Content-Type: application/fhir+json;charset=utf-8
 ----
 {
   "resourceType": "Communication",
-  "id": "12350",
+  "id": "7101a5e5-4b54-4199-95f5-ffc505c8a33b",
   "meta": {
     "versionId": "1",
     "lastUpdated": "2020-03-12T18:01:10+00:00",
@@ -747,7 +747,7 @@ Content-Type: application/fhir+json;charset=utf-8
       "fullUrl": "https://erp.zentral.erp.splitdns.ti-dienste.de/Communication/12346",
       "resource": {
         "resourceType": "Communication",
-        "id": "12346",
+        "id": "8f9bb3ea-3480-45ea-bb0b-ffd33c57e4af",
         "meta": {
           "versionId": "1",
           "lastUpdated": "2020-03-12T18:15:10+00:00",
@@ -892,7 +892,7 @@ Content-Type: application/fhir+xml;charset=utf-8
         <fullUrl value="https://erp.zentral.erp.splitdns.ti-dienste.de/Communication/74671"/>
         <resource>
             <Communication xmlns="http://hl7.org/fhir">
-                <id value="74671"/>
+                <id value="7b79abbe-1f21-47d1-a5ff-df921c5e6815"/> 
                 <meta>
                     <versionId value="1"/>
                     <lastUpdated value="2020-04-12T18:01:10+00:00"/>


### PR DESCRIPTION
Die IDs der Communication Beispiele waren bisher keine UUIDs. Dieser PR ändert sie so, dass sie nun echte UUIDs sind.