### PR TITLE
Entfernen der Notizen zum Verbot von personenbezogenen und medizinischen Information im KIM-Header Subject

### DIFF
--- a/docs/erp_steuerung_durch_le.adoc
+++ b/docs/erp_steuerung_durch_le.adoc
@@ -401,7 +401,7 @@ Content-Type: text/plain;charset=UTF-8
 Task/169.774.328.939.869.74/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea
 --boundarymultipartseparator42
 ----
-NOTE: `Subject:` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
+NOTE: `Subject:` enthält den wählbaren Titel der Nachricht.
 
 NOTE: Für die Zuweisung eines E-Rezeptes an die Apotheke muss der Wert `X-KIM-Dienstkennung` gesetzt sein.  +
 
@@ -432,7 +432,7 @@ TextTextTextTextTextTextTextTextText
 Mit den besten Gruessen
 Apotheke 123
 ----
-NOTE: `Subject` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
+NOTE: `Subject` enthält den wählbaren Titel der Nachricht.
 
 NOTE: Für die Zuweisung eines E-Rezeptes an die Apotheke muss die `X-KIM-Dienstkennung` gesetzt sein.
 
@@ -464,7 +464,7 @@ TextTextTextTextTextTextTextTextText
 Mit den besten Gruessen
 Arzt ABC
 ----
-NOTE: `Subject` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
+NOTE: `Subject` enthält den wählbaren Titel der Nachricht.
 
 NOTE: Für die Zuweisung eines E-Rezeptes an die Apotheke muss die `X-KIM-Dienstkennung` gesetzt sein.
 

--- a/docs_sources/erp_steuerung_durch_le-source.adoc
+++ b/docs_sources/erp_steuerung_durch_le-source.adoc
@@ -238,7 +238,7 @@ Eine Nachricht dient der direkten Zuweisung eines E-Rezeptes an eine Apotheke. D
 ----
 include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/05_emailPlainZuweisungInDerApotheke.txt[]
 ----
-NOTE: `Subject:` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
+NOTE: `Subject:` enthält den wählbaren Titel der Nachricht. 
 
 NOTE: Für die Zuweisung eines E-Rezeptes an die Apotheke muss der Wert `X-KIM-Dienstkennung` gesetzt sein.  +
 
@@ -250,7 +250,7 @@ NOTE: Aus Gründen der Lesbarkeit wurde der angehängte Therapieplan stark mit `
 ----
 include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/06_emailPlainFreieKommunikation.txt[]
 ----
-NOTE: `Subject` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
+NOTE: `Subject` enthält den wählbaren Titel der Nachricht. 
 
 NOTE: Für die Zuweisung eines E-Rezeptes an die Apotheke muss die `X-KIM-Dienstkennung` gesetzt sein.
 
@@ -262,7 +262,7 @@ Um auf KIM-Nachrichten zu Antworten ist nach Standardprotokoll der Header "In-Re
 ----
 include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_steuerung_durch_le/07_emailPlainFreieKommunikation_reply.txt[]
 ----
-NOTE: `Subject` enthält den wählbaren Titel der Nachricht. Es dürfen keine personenbezogenen oder medizinischen Informationen enthalten sein. +
+NOTE: `Subject` enthält den wählbaren Titel der Nachricht. 
 
 NOTE: Für die Zuweisung eines E-Rezeptes an die Apotheke muss die `X-KIM-Dienstkennung` gesetzt sein.
 


### PR DESCRIPTION
Diese Pull-Request entfernt die Notizen, die darauf hinweisen, dass es verboten ist, personenbezogenen oder medizinischen Informationen im Betreff einer KIM-Nachricht zu enthalten