### PR TITLE
Den zusätzlichen Text aus den Beispielen extrahieren

### DIFF
--- a/docs/authentisieren.adoc
+++ b/docs/authentisieren.adoc
@@ -180,6 +180,9 @@ NOTE: In `<ns8:CertRef>C.AUT</ns8:CertRef>` wird angegeben, dass das Zertifikat 
 HTTP/1.1 200 OK
 Content-Type: text/xml;charset=utf-8
 
+HTTP/1.1 200 OK
+Content-Type: text/xml;charset=utf-8
+
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <soap:Body>
         <ns3:ReadCardCertificateResponse xmlns="http://ws.gematik.de/conn/ConnectorCommon/v5.0"
@@ -559,6 +562,10 @@ Nach dem erfolgreichen Abschluss der Bearbeitung des Requests durch die VAU des 
 Der HTTP-Statuscode 200 signalisiert dabei die korrekte Verarbeitung und Erstellung der verschlüsselten Antwort. Die innere HTTP-Response des fachlichen Ergebnisses aus der VAU kann dabei einen abweichenden HTTP-Statuscode beinhalten, wenn aufgrund der Daten oder Verarbeitung innerhalb der VAU Fehlerzustände eintreten oder ungültige Daten übergeben wurden. Sei `001111101111100110001001001111010110010010111110101100100011110...` die verschlüsselte Response zum obigen Beispiel. Die Entschlüsselung mit dem für den Request generierten Antwortschlüssel `16bac90134c635e4ec85fae0e4885d9f`mittels AES-GCM liefert die innere HTTP-Response der VAU als leerzeichengetrennte Zeichenkette:
 [source,json]
 ----
+1 b69f01734f34376ddcdbdbe9af18a06f HTTP/1.1 200 OK
+Content-Type: application/fhir+json;charset=utf-8
+Content-Location: https://erp.zentral.erp.splitdns.ti-dienste.de/Bundle/f5ba6eaf-9052-42f6-ac4e-fadceed7293b
+
 1 b69f01734f34376ddcdbdbe9af18a06f HTTP/1.1 200 OK
 Content-Type: application/fhir+json;charset=utf-8
 Content-Location: https://erp.zentral.erp.splitdns.ti-dienste.de/Bundle/f5ba6eaf-9052-42f6-ac4e-fadceed7293b

--- a/docs/erp_bereitstellen.adoc
+++ b/docs/erp_bereitstellen.adoc
@@ -1056,6 +1056,9 @@ IMPORTANT: Der Parameter `IncludeRevocationInfo = true` ist von herausragender B
 HTTP/1.1 200 OK
 Content-Type: text/xml;charset=utf-8
 
+HTTP/1.1 200 OK
+Content-Type: text/xml;charset=utf-8
+
 <SOAP-ENV:Envelope
     xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
     <SOAP-ENV:Header/>

--- a/docs_sources/authentisieren-source.adoc
+++ b/docs_sources/authentisieren-source.adoc
@@ -141,6 +141,9 @@ NOTE: In `<ns8:CertRef>C.AUT</ns8:CertRef>` wird angegeben, dass das Zertifikat 
 *Response*
 [source,xml]
 ----
+HTTP/1.1 200 OK
+Content-Type: text/xml;charset=utf-8
+
 include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/02_response_ReadCardCertificate.xml[]
 ----
 NOTE: Der Konnektor liefert das Zertifikat in `<ns5:X509Certificate>` zurück, wie es auf der Karte gespeichert ist, ASN.1 DER codiert in Base64-Darstellung.
@@ -413,6 +416,10 @@ Nach dem erfolgreichen Abschluss der Bearbeitung des Requests durch die VAU des 
 Der HTTP-Statuscode 200 signalisiert dabei die korrekte Verarbeitung und Erstellung der verschlüsselten Antwort. Die innere HTTP-Response des fachlichen Ergebnisses aus der VAU kann dabei einen abweichenden HTTP-Statuscode beinhalten, wenn aufgrund der Daten oder Verarbeitung innerhalb der VAU Fehlerzustände eintreten oder ungültige Daten übergeben wurden. Sei `001111101111100110001001001111010110010010111110101100100011110...` die verschlüsselte Response zum obigen Beispiel. Die Entschlüsselung mit dem für den Request generierten Antwortschlüssel `16bac90134c635e4ec85fae0e4885d9f`mittels AES-GCM liefert die innere HTTP-Response der VAU als leerzeichengetrennte Zeichenkette:
 [source,json]
 ----
+1 b69f01734f34376ddcdbdbe9af18a06f HTTP/1.1 200 OK
+Content-Type: application/fhir+json;charset=utf-8
+Content-Location: https://erp.zentral.erp.splitdns.ti-dienste.de/Bundle/f5ba6eaf-9052-42f6-ac4e-fadceed7293b
+
 include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/authentisieren/07_response_InnerVau.json[]
 ----
 

--- a/docs_sources/erp_bereitstellen-source.adoc
+++ b/docs_sources/erp_bereitstellen-source.adoc
@@ -204,6 +204,9 @@ IMPORTANT: Der Parameter `IncludeRevocationInfo = true` ist von herausragender B
 *Response*
 [source,xml]
 ----
+HTTP/1.1 200 OK
+Content-Type: text/xml;charset=utf-8
+
 include::https://raw.githubusercontent.com/gematik/eRezept-Examples/main/API-Examples/2024-11-01/erp_bereitstellen/04_response_SignDocument.xml[]
 ----
 NOTE: Das Ergebnis der erfolgreichen qualifizierten Signatur wird Base64-codiert in `<ns5:SignatureObject>` zurückgegeben. Darin enthalten ist eine PKCS#7-Datei in HEX-Codierung, die mit einem ASN1-Decoder angesehen werden kann.


### PR DESCRIPTION
Manche Beispiele enthalten zusätzliche Texte, die aus den Beispieldateien entfernt werden müssen. Diese Texte wurden in diesem Repository wieder hinzugefügt, da sie noch wichtig sind.