### PR TITLE
removed link to BfArM Visualizer

### DIFF
--- a/docs/erp_eml-epa-notes.adoc
+++ b/docs/erp_eml-epa-notes.adoc
@@ -356,8 +356,6 @@ Jede Stelle aus den Profilen KBV_PR_ERP_Medication_FreeText, KBV_PR_ERP_Medicati
 
 === Erzeugen von Medications für Rezepturen und Kombipackungen
 
-NOTE: Zur Veranschaulichung der Daten kann der link:https://bfarm-referenzdatenbank-explorer-frontend.onrender.com/[BfArM Data Explorer] genutzt werden. Hier können für PZN-Medications entsprechende FHIR-Ressourcen im Zielprofil erzeugt werden.
-
 Die Darstellung von Rezepturen und Kombipackungen in der ePA unterscheidet sich zum Profil KBV_PR_ERP_Medication_Compounding.
 
 In KBV_PR_ERP_Medication_Compounding sind die Bestandteile einer Rezeptur in _einer_ Medication als PZN Codes unter .ingredient aufzulisten. Die anzugebenen Bestandteile können vom Arzt bzw. Apotheker ausgewählt werden.

--- a/docs_sources/erp_eml-epa-notes-source.adoc
+++ b/docs_sources/erp_eml-epa-notes-source.adoc
@@ -60,8 +60,6 @@ Jede Stelle aus den Profilen KBV_PR_ERP_Medication_FreeText, KBV_PR_ERP_Medicati
 
 === Erzeugen von Medications für Rezepturen und Kombipackungen
 
-NOTE: Zur Veranschaulichung der Daten kann der link:https://bfarm-referenzdatenbank-explorer-frontend.onrender.com/[BfArM Data Explorer] genutzt werden. Hier können für PZN-Medications entsprechende FHIR-Ressourcen im Zielprofil erzeugt werden.
-
 Die Darstellung von Rezepturen und Kombipackungen in der ePA unterscheidet sich zum Profil KBV_PR_ERP_Medication_Compounding.
 
 In KBV_PR_ERP_Medication_Compounding sind die Bestandteile einer Rezeptur in _einer_ Medication als PZN Codes unter .ingredient aufzulisten. Die anzugebenen Bestandteile können vom Arzt bzw. Apotheker ausgewählt werden.


### PR DESCRIPTION
Removed Link to no longer available BfARM Data Visualizer. Context: https://github.com/gematik/eRezept-Examples/issues/68