### PR TITLE
Change wording for Dispensierinformationen

### DIFF
--- a/docs/erp_abrufen_dispense.adoc
+++ b/docs/erp_abrufen_dispense.adoc
@@ -1,4 +1,4 @@
-= E-Rezept API-Dokumentation für Abgabeinformationen image:gematik_logo.png[width=150, float="right"]
+= E-Rezept API-Dokumentation für Dispensierinformationen image:gematik_logo.png[width=150, float="right"]
 // asciidoc settings for DE (German)
 // ==================================
 :imagesdir: ../images
@@ -22,7 +22,7 @@
 
 Zielgruppe: image:{AVS}[]
 
-Hier dokumentiert die gematik Hinweise für die Erstellung von Abgabeinformationen bei der Abgabe von Medikamenten. Diese Beschreibungen sind für die Operationen $disense (xref:../docs/erp_abrufen.adoc#E-Rezept Abgabe zeitnah dokumentieren["E-Rezept Abgabe zeitnah dokumentieren"]) und $close (xref:../docs/erp_abrufen.adoc#E-Rezept-Abgabe vollziehen["E-Rezept-Abgabe vollziehen"]) relevant.
+Hier dokumentiert die gematik Hinweise für die Erstellung von Dispensierinformationen bei der Abgabe von Medikamenten. Diese Beschreibungen sind für die Operationen $disense (xref:../docs/erp_abrufen.adoc#E-Rezept Abgabe zeitnah dokumentieren["E-Rezept Abgabe zeitnah dokumentieren"]) und $close (xref:../docs/erp_abrufen.adoc#E-Rezept-Abgabe vollziehen["E-Rezept-Abgabe vollziehen"]) relevant.
 
 toc::[]
 
@@ -169,7 +169,7 @@ Hier ist ein Beispiel, wie eine FHIR-Ressource Medication für ein Fertigarzneim
 
 ====
 
-== Profilversion der Abgabeinformationen
+== Profilversion der Dispensierinformationen
 
 Das Datenmodell für die Abgabe bei den Operationen $dispense und $close sieht vor, dass eine Parameters Ressource mit 1..* `.parameter[rxDispensation]` übergeben werden kann. Nach Datenmodell muss die Profilversion aller enthaltenen Ressourcen (MedicationDispense und Medication) die *gleiche* Profilversion tragen.
 Die Gültigkeit der Profilversion wird nach dem jüngsten Datum aller MedicationDispense.whenHandedOver (max(.whenHandedOver)) bestimmt.
@@ -184,13 +184,13 @@ So wird am Ende des Profilübergangs 1.3 zu 1.4 am 15.04. folgendes Verhalten er
 
 1. Ein AVS beliefert den ersten Teil der Verordnung am 10.04.
 ** Es gibt eine MedicationDispense mit .whenHandedOver = 2025-04-10
-** Das AVS erstellt die Abgabeinformationen mit Profilversion 1.2, 1.3 oder 1.4
+** Das AVS erstellt die Dispensierinformationen mit Profilversion 1.2, 1.3 oder 1.4
 2. Das AVS beliefert den restlichen Teil der Verordnung am 22.04.
 ** Um die Belieferung abzuschließen, erstellt das AVS eine Parameters Ressource mit
 ** MedicationDispense_1.whenHandedOver = 2025-04-10
 ** MedicationDispense_2.whenHandedOver = 2025-04-22
-** Das AVS erstellt die Abgabeinformationen mit Profilversion 1.4
+** Das AVS erstellt die Dispensierinformationen mit Profilversion 1.4
 
 image:parameters-max-whenhandedover.png[]
 
-Die zu verwendende Profilversion richtet sich nach dem jüngsten Datum aller MedicationDispense.whenHandedOver (max(.whenHandedOver)), also 2025-04-22, damit ist die Profilversion 1.4 für alle Ressourcen der Abgabeinformationen zu verwenden.
+Die zu verwendende Profilversion richtet sich nach dem jüngsten Datum aller MedicationDispense.whenHandedOver (max(.whenHandedOver)), also 2025-04-22, damit ist die Profilversion 1.4 für alle Ressourcen der Dispensierinformationen zu verwenden.

--- a/docs_sources/erp_abrufen_dispense-source.adoc
+++ b/docs_sources/erp_abrufen_dispense-source.adoc
@@ -1,9 +1,9 @@
-= E-Rezept API-Dokumentation für Abgabeinformationen image:gematik_logo.png[width=150, float="right"]
+= E-Rezept API-Dokumentation für Dispensierinformationen image:gematik_logo.png[width=150, float="right"]
 include::./config-source.adoc[]
 
 Zielgruppe: image:{AVS}[]
 
-Hier dokumentiert die gematik Hinweise für die Erstellung von Abgabeinformationen bei der Abgabe von Medikamenten. Diese Beschreibungen sind für die Operationen $disense (xref:../docs/erp_abrufen.adoc#E-Rezept Abgabe zeitnah dokumentieren["E-Rezept Abgabe zeitnah dokumentieren"]) und $close (xref:../docs/erp_abrufen.adoc#E-Rezept-Abgabe vollziehen["E-Rezept-Abgabe vollziehen"]) relevant.
+Hier dokumentiert die gematik Hinweise für die Erstellung von Dispensierinformationen bei der Abgabe von Medikamenten. Diese Beschreibungen sind für die Operationen $disense (xref:../docs/erp_abrufen.adoc#E-Rezept Abgabe zeitnah dokumentieren["E-Rezept Abgabe zeitnah dokumentieren"]) und $close (xref:../docs/erp_abrufen.adoc#E-Rezept-Abgabe vollziehen["E-Rezept-Abgabe vollziehen"]) relevant.
 
 toc::[]
 
@@ -150,7 +150,7 @@ Hier ist ein Beispiel, wie eine FHIR-Ressource Medication für ein Fertigarzneim
 
 ====
 
-== Profilversion der Abgabeinformationen
+== Profilversion der Dispensierinformationen
 
 Das Datenmodell für die Abgabe bei den Operationen $dispense und $close sieht vor, dass eine Parameters Ressource mit 1..* `.parameter[rxDispensation]` übergeben werden kann. Nach Datenmodell muss die Profilversion aller enthaltenen Ressourcen (MedicationDispense und Medication) die *gleiche* Profilversion tragen.
 Die Gültigkeit der Profilversion wird nach dem jüngsten Datum aller MedicationDispense.whenHandedOver (max(.whenHandedOver)) bestimmt.
@@ -165,13 +165,13 @@ So wird am Ende des Profilübergangs 1.3 zu 1.4 am 15.04. folgendes Verhalten er
 
 1. Ein AVS beliefert den ersten Teil der Verordnung am 10.04. 
 ** Es gibt eine MedicationDispense mit .whenHandedOver = 2025-04-10
-** Das AVS erstellt die Abgabeinformationen mit Profilversion 1.2, 1.3 oder 1.4
+** Das AVS erstellt die Dispensierinformationen mit Profilversion 1.2, 1.3 oder 1.4
 2. Das AVS beliefert den restlichen Teil der Verordnung am 22.04.
 ** Um die Belieferung abzuschließen, erstellt das AVS eine Parameters Ressource mit
 ** MedicationDispense_1.whenHandedOver = 2025-04-10
 ** MedicationDispense_2.whenHandedOver = 2025-04-22
-** Das AVS erstellt die Abgabeinformationen mit Profilversion 1.4
+** Das AVS erstellt die Dispensierinformationen mit Profilversion 1.4
 
 image:parameters-max-whenhandedover.png[]
 
-Die zu verwendende Profilversion richtet sich nach dem jüngsten Datum aller MedicationDispense.whenHandedOver (max(.whenHandedOver)), also 2025-04-22, damit ist die Profilversion 1.4 für alle Ressourcen der Abgabeinformationen zu verwenden.
+Die zu verwendende Profilversion richtet sich nach dem jüngsten Datum aller MedicationDispense.whenHandedOver (max(.whenHandedOver)), also 2025-04-22, damit ist die Profilversion 1.4 für alle Ressourcen der Dispensierinformationen zu verwenden.


### PR DESCRIPTION
In order to harmonize with gemILF_PS_eRp the wording for "Abgabeinformationen" has been replaced with "Dispensierinformationen" in erp_abrufen_dispense