### PR TITLE
Add examples for invalid references and fix epa drug categories in build

### DIFF
--- a/docs/erp_abrufen.adoc
+++ b/docs/erp_abrufen.adoc
@@ -975,6 +975,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
                     </meta>
                     <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension">
                         <valueCoding>
+                            <system value="https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"/>
                             <code value="00"/>
                         </valueCoding>
                     </extension>
@@ -1116,6 +1117,7 @@ Für die Übertragung der Abgabeinformationen wird als Transportmedium die FHIR-
                     </meta>
                     <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension">
                         <valueCoding>
+                            <system value="https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"/>
                             <code value="00"/>
                         </valueCoding>
                     </extension>
@@ -1234,6 +1236,7 @@ Für die Übertragung der Abgabeinformationen wird als Transportmedium die FHIR-
                     </meta>
                     <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension">
                         <valueCoding>
+                            <system value="https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"/>
                             <code value="00"/>
                         </valueCoding>
                     </extension>
@@ -1397,6 +1400,7 @@ NOTE: Im http-Header des äußeren http-Requests an die VAU (POST /VAU) sind die
                     </meta>
                     <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension">
                         <valueCoding>
+                            <system value="https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"/>
                             <code value="00"/>
                         </valueCoding>
                     </extension>
@@ -1541,6 +1545,7 @@ Für die Übertragung der Abgabeinformationen wird als Transportmedium die FHIR-
                     </meta>
                     <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension">
                         <valueCoding>
+                            <system value="https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"/>
                             <code value="00"/>
                         </valueCoding>
                     </extension>
@@ -1659,6 +1664,7 @@ Für die Übertragung der Abgabeinformationen wird als Transportmedium die FHIR-
                     </meta>
                     <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension">
                         <valueCoding>
+                            <system value="https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"/>
                             <code value="00"/>
                         </valueCoding>
                     </extension>

--- a/docs/erp_eml-epa-notes.adoc
+++ b/docs/erp_eml-epa-notes.adoc
@@ -101,6 +101,7 @@ Im folgenden ein Beispiel für die Übermittlung eines Abgabedatensatzes mit den
                     </meta>
                     <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension">
                         <valueCoding>
+                            <system value="https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"/>
                             <code value="00"/>
                         </valueCoding>
                     </extension>
@@ -237,6 +238,7 @@ image:parameters-schematics-multiple.png[width=50%]
                     </meta>
                     <extension url="https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension">
                         <valueCoding>
+                            <system value="https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"/>
                             <code value="00"/>
                         </valueCoding>
                     </extension>

--- a/docs/erp_fhir_infos.adoc
+++ b/docs/erp_fhir_infos.adoc
@@ -79,6 +79,8 @@ Hier das korrigierte Beispiel:
                 <id value="bc329f24-3d65-4286-bf06-b54dd6cad655" />
 ----
 
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/01_INVALID_fullUrl_and_id_missmatch.xml[E-Rezept Example: id missmatch].
+
 ==== Einheitliche Referenzierung in Bundles
 Zur Vermeidung von Fehlern bei der Referenzierung von Ressourcen in Bundles sollte eine einheitliche Referenzierung genutzt werden. Das bedeutet, dass absolute und relative Referenzierung nicht gemischt werden sollte. Zur Eindeutigkeit und besseren Lesbarkeit wird empfohlen, durchgehend absolute Referenzen zu verwenden.
 
@@ -123,6 +125,8 @@ Alternativ ein korrektes Beispiel für relative Referenzierung:
       </section>
 ----
 
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/02_INVALID_mixed_reference.xml[E-Rezept Example: mixed reference].
+
 
 ==== Format von fullURLs
 fullURLs müssen entweder als URL-Schema oder als URN-Schema angegeben werden. Wenn das URL-Schema verwendet wird, muss dieses nach dem link:https://hl7.org/fhir/R4/references.html#regex[Regex für FHIR-URLs] aufgebaut sein. Folgende Hinweise sind zu beachten:
@@ -146,6 +150,8 @@ Gültige Referenzen:
 <fullUrl value="urn:uuid:4b7e4c01-6ee6-43ee-b527-61a813efa6be" /> <!-- Korrekte UUID nach RFC4122 -->
 ----
 
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/03_INVALID_fullUrl_format.xml[E-Rezept Example: invalid fullUrl format].
+
 WARNING: Der E-Rezept-Fachdienst leht die Referenzierung von Bundles mit `urn:oid` in Zukunft ab. Diese sind zwar laut FHIR erlaubt, werden aber zur Verminderung von Aufwänden nicht unterstützt. Daher DARF diese Art der Referenzierung NICHT verwendet werden.
 
 Beispiel einer `ungültigen` urn:oid: Referenzierung:
@@ -156,6 +162,8 @@ Beispiel einer `ungültigen` urn:oid: Referenzierung:
    <resource>
         ...
 ----
+
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/05_INVALID_oid_format.xml[E-Rezept Example: invalid urn:oid Bundle].
 
 ==== Ressourcen ohne .id
 Ressourcen, die in Bundles enthalten sind, müssen eine .id besitzen. Dies ist notwendig, um die Ressourcen eindeutig referenzieren und identifizieren zu können. Daher müssen diese angegeben werden auch wenn das Datenmodell keine Kardinalität von 1..1 für das Feld .id vorsieht.
@@ -185,6 +193,7 @@ Beispiel für korrekte Angabe der .id:
             </Practitioner>
 ----
 
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/04_Invalid_Example_Patient_no_id.xml[E-Rezept Example: resource without id].
 
 == Tools und Hinweise zu FHIR
 

--- a/docs/erp_versicherte.adoc
+++ b/docs/erp_versicherte.adoc
@@ -1623,7 +1623,8 @@ Content-Type: application/fhir+json;charset=utf-8
           {
             "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
             "valueCoding": {
-              "code": "00"
+              "code": "00",
+              "system": "https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"
             }
           },
           {
@@ -2262,7 +2263,8 @@ Content-Type: application/fhir+json;charset=utf-8
           {
             "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
             "valueCoding": {
-              "code": "00"
+              "code": "00",
+              "system": "https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"
             }
           },
           {
@@ -2494,7 +2496,8 @@ Content-Type: application/fhir+json;charset=utf-8
           {
             "url": "https://gematik.de/fhir/epa-medication/StructureDefinition/drug-category-extension",
             "valueCoding": {
-              "code": "00"
+              "code": "00",
+              "system": "https://gematik.de/fhir/epa-medication/CodeSystem/epa-drug-category-cs"
             }
           },
           {

--- a/docs_sources/erp_fhir_infos-source.adoc
+++ b/docs_sources/erp_fhir_infos-source.adoc
@@ -60,6 +60,8 @@ Hier das korrigierte Beispiel:
                 <id value="bc329f24-3d65-4286-bf06-b54dd6cad655" />
 ----
 
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/01_INVALID_fullUrl_and_id_missmatch.xml[E-Rezept Example: id missmatch].
+
 ==== Einheitliche Referenzierung in Bundles
 Zur Vermeidung von Fehlern bei der Referenzierung von Ressourcen in Bundles sollte eine einheitliche Referenzierung genutzt werden. Das bedeutet, dass absolute und relative Referenzierung nicht gemischt werden sollte. Zur Eindeutigkeit und besseren Lesbarkeit wird empfohlen, durchgehend absolute Referenzen zu verwenden.
 
@@ -104,6 +106,8 @@ Alternativ ein korrektes Beispiel für relative Referenzierung:
       </section>
 ----
 
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/02_INVALID_mixed_reference.xml[E-Rezept Example: mixed reference].
+
 
 ==== Format von fullURLs
 fullURLs müssen entweder als URL-Schema oder als URN-Schema angegeben werden. Wenn das URL-Schema verwendet wird, muss dieses nach dem link:https://hl7.org/fhir/R4/references.html#regex[Regex für FHIR-URLs] aufgebaut sein. Folgende Hinweise sind zu beachten:
@@ -127,6 +131,8 @@ Gültige Referenzen:
 <fullUrl value="urn:uuid:4b7e4c01-6ee6-43ee-b527-61a813efa6be" /> <!-- Korrekte UUID nach RFC4122 -->
 ----
 
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/03_INVALID_fullUrl_format.xml[E-Rezept Example: invalid fullUrl format].
+
 WARNING: Der E-Rezept-Fachdienst leht die Referenzierung von Bundles mit `urn:oid` in Zukunft ab. Diese sind zwar laut FHIR erlaubt, werden aber zur Verminderung von Aufwänden nicht unterstützt. Daher DARF diese Art der Referenzierung NICHT verwendet werden.
 
 Beispiel einer `ungültigen` urn:oid: Referenzierung:
@@ -137,6 +143,8 @@ Beispiel einer `ungültigen` urn:oid: Referenzierung:
    <resource>
         ...
 ----
+
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/05_INVALID_oid_format.xml[E-Rezept Example: invalid urn:oid Bundle].
 
 ==== Ressourcen ohne .id
 Ressourcen, die in Bundles enthalten sind, müssen eine .id besitzen. Dies ist notwendig, um die Ressourcen eindeutig referenzieren und identifizieren zu können. Daher müssen diese angegeben werden auch wenn das Datenmodell keine Kardinalität von 1..1 für das Feld .id vorsieht.
@@ -166,6 +174,7 @@ Beispiel für korrekte Angabe der .id:
             </Practitioner>
 ----
 
+Ein weiteres Beispiel für eine *ungültige* Referenzierung findet sich auf link:https://github.com/gematik/eRezept-Examples/blob/main/API-Examples/2025-01-15/erp_fhir_infos/04_Invalid_Example_Patient_no_id.xml[E-Rezept Example: resource without id].
 
 == Tools und Hinweise zu FHIR
 


### PR DESCRIPTION
Introduce examples for invalid references in the documentation and ensure the correct drug category system is included in the relevant extensions.