### PR TITLE
Aktualisierte Liste aktiver IK-Nummern für eVO DiGA und angepasste Starttermine

### DIFF
--- a/docs_sources/erp_diga-source.adoc
+++ b/docs_sources/erp_diga-source.adoc
@@ -9,17 +9,21 @@ toc::[]
 
 == Aktuell Aktive IK-Nummern für eVO DiGA 
 
-Ausschließlich die folgenden (Betriebs-) Krankenkassen können ab dem 06.05.2025 die eVO DiGA entgegennehmen:
+Ausschließlich die folgenden (Betriebs-)Krankenkassen können ab dem 15.05.2025 die eVO DiGA entgegennehmen:
 
-* AOK Rheinland/Hamburg – IK 104212505
-* Pronova BKK – IK 106492393
-* R+V BKK – IK 105823040
-* BIG direkt gesund – IK 103501080
-* IKK classic – IK 107202793
-* hkk – IK 103170002
-* DAK – IK 105830016
-* TK – IK 101575519
-* Barmer – IK 104940005
+*	AOK Rheinland/Hamburg – IK 104212505
+*	Pronova BKK – IK 106492393
+*	R+V BKK – IK 105823040
+*	BIG direkt gesund – IK 103501080
+*	IKK classic – IK 107202793
+*	hkk – IK 103170002
+*	DAK – IK 105830016
+*	TK – IK 101575519
+
+Die folgende Krankenkasse kann voraussichtlich ab dem 01.06.2025 die eVO DiGA entgegennehmen:
+
+*	Barmer – IK 104940005
+
 
 Für alle anderen (Betriebs-) Krankenkassen soll bis zur verpflichtenden bundesweiten Nutzung der eVO DiGA weiterhin das Muster 16 (M16) DiGA verwendet werden.
 


### PR DESCRIPTION
- Verschiebung des Startdatums auf den 15.05.2025 für acht Kassen
- Barmer voraussichtlich ab dem 01.06.2025 aufgenommen
- Hinweis zur Nutzung von Muster 16 bei anderen Kassen beibehalten