### PR TITLE
Erläuterung für 33 Byte große Koordinaten

### DIFF
--- a/samples/snippets/VAUClientCrypto.java
+++ b/samples/snippets/VAUClientCrypto.java
@@ -139,8 +139,11 @@ public class VAUClientCrypto {
 	 */
 	private byte[] pad32(byte[] input) {
 
-		// this requires some rework or analysis - in some cases I noticed the X/Y
-		// coordinates from EC Key had 33 bytes instead of 32.
+		// Der Zahlwert der Koordinaten kann eine Größe von 32 Byte haben. Da BigInteger::toByteArray die Zahl in
+		// Zweier-Komplement-Darstellung ausgibt, kann ein 33 Byte (32 Byte Zahlwert + 1 Byte Vorzeichen) großer
+		// Wert entstehen. In diesem Fall schneiden wir die führende Null (welche das positive Vorzeichen
+		// repräsentiert) ab. Alle Koordinaten müssen positiv sein, weil elliptische Kurven basierend auf
+		// mathematischen Gruppen definiert sind.
 		if (input[0] == 0 && input.length > 32) {
 			byte[] tmp = new byte[input.length - 1];
 			System.arraycopy(input, 1, tmp, 0, tmp.length);


### PR DESCRIPTION
Erkläuterung warum beim Padding der Byte-Representation der X,Y Koordinaten einer EC-Verschlüsselung 33 Byte große Werte entstehen könnnen und warum es ausreicht nur 32 Byte zu übertragen.