### PR TITLE
Add errorcodes for read access code

### DIFF
--- a/docs/erp_eprescription.adoc
+++ b/docs/erp_eprescription.adoc
@@ -607,6 +607,18 @@ FHIR-Profil: link:https://gematik.de/fhir/erp-eu/StructureDefinition/GEM_ERPEU_P
 ¦200 ¦ Success +
 [small]#Zugriffscode erfolgreich abgefragt#
 
+¦400 ¦ Client Error +
+[small]#Die Anfrage-Nachricht war fehlerhaft aufgebaut.#
+
+¦401 ¦ Client Error +
+[small]#Die Anfrage kann nicht ohne gültige Authentifizierung durchgeführt werden. Wie die Authentifizierung durchgeführt werden soll, wird im "WWW-Authenticate"-Header-Feld der Antwort übermittelt.#
+
+¦403 ¦ Client Error +
+[small]#Die Anfrage wurde mangels Berechtigung des Clients nicht durchgeführt, bspw. weil der authentifizierte Benutzer nicht berechtigt ist.#
+
+¦404 ¦ Client Error +
+[small]#Zugriffsberechtigung nicht gefunden#
+
 |===
 
 === Löschen des Zugriffscodes im E-Rezept-Fachdienst

--- a/resources/openapi/e_prescription.yml
+++ b/resources/openapi/e_prescription.yml
@@ -362,6 +362,17 @@ paths:
             application/fhir+json:
               example:
                 $ref: "https://raw.githubusercontent.com/gematik/eRezept-Examples/refs/heads/2025-10-01/API-Examples/2025-10-01/erp_eprescription/04_POST_AccessCode_EU_Response.json"
+        '400':
+          description: Die Anfrage-Nachricht war fehlerhaft aufgebaut.
+        '401':
+          description: Die Anfrage kann nicht ohne gültige Authentifizierung durchgeführt werden. Wie die Authentifizierung durchgeführt werden soll, wird im "WWW-Authenticate"-Header-Feld der Antwort übermittelt.
+        '403':
+          description: Die Anfrage wurde mangels Berechtigung des Clients nicht durchgeführt, bspw. weil der authentifizierte Benutzer nicht berechtigt ist.
+        '404':
+          description: Zugriffsberechtigung nicht gefunden
+          content:
+            application/fhir+json:
+              example: FHIR-OperationOutcome mit issue.text = 'Zugriffsberechtigung nicht gefunden'
 
   /$revoke-eu-access-permission:
     delete:


### PR DESCRIPTION
This pull request introduces updates to document and define HTTP error responses for the E-Prescription service. The changes ensure consistency between the documentation and the OpenAPI specification by adding descriptions for error codes such as `400`, `401`, `403`, and `404`.

### Documentation Updates:
* [`docs/erp_eprescription.adoc`](diffhunk://#diff-b1972686cf988a89b5b3587f854913faf1bad86153a4e37d932a24705d228b3bR610-R621): Added descriptions for HTTP error codes `400`, `401`, `403`, and `404`, explaining scenarios such as malformed requests, authentication issues, lack of client permissions, and missing access permissions.

### OpenAPI Specification Updates:
* [`resources/openapi/e_prescription.yml`](diffhunk://#diff-3ca83a617809fe662b3d48c198d3d2ad8714ce426933923ec7b00e6eafad5319R365-R375): Defined HTTP error responses `400`, `401`, `403`, and `404`, including descriptions and an example for `404` using a FHIR `OperationOutcome`.