### PR TITLE
RU-DEV Subscription endpoint added

### DIFF
--- a/docs/erp_notification_avs.adoc
+++ b/docs/erp_notification_avs.adoc
@@ -150,7 +150,8 @@ Sec-WebSocket-Key: q4xkcO32u266gldTuKaSOw==
 TIP: Dieser Request ist NICHT zusätzlich VAU-verschlüsselt, sondern wird TLS-verschlüsselt an den Subscription-Endpunkt geschickt.
 
 TIP: Je nach eingesetztem Framework lautet die Zieladresse dann `wss://subscription.zentral.erp.splitdns.ti-dienste.de:443` +
-bzw. zum Test in der TI-Referenzumgebung RU = `wss://subscription-ref.zentral.erp.splitdns.ti-dienste.de:443`
+bzw. zum Test in der TI-Referenzumgebung RU `wss://subscription-ref.zentral.erp.splitdns.ti-dienste.de:443` +
+oder für RU-DEV `wss://subscription-dev.zentral.erp.splitdns.ti-dienste.de:443`
 
 |===
 NOTE: In `Authorization:` wird das von der VAU generierte Bearer Token mit dem Pseudonym über die Telematik-ID übergeben.

--- a/docs_sources/erp_notification_avs-source.adoc
+++ b/docs_sources/erp_notification_avs-source.adoc
@@ -111,7 +111,8 @@ Sec-WebSocket-Key: q4xkcO32u266gldTuKaSOw==
 TIP: Dieser Request ist NICHT zusätzlich VAU-verschlüsselt, sondern wird TLS-verschlüsselt an den Subscription-Endpunkt geschickt.
 
 TIP: Je nach eingesetztem Framework lautet die Zieladresse dann `wss://subscription.zentral.erp.splitdns.ti-dienste.de:443` +
-bzw. zum Test in der TI-Referenzumgebung RU = `wss://subscription-ref.zentral.erp.splitdns.ti-dienste.de:443`
+bzw. zum Test in der TI-Referenzumgebung RU `wss://subscription-ref.zentral.erp.splitdns.ti-dienste.de:443` +
+oder für RU-DEV `wss://subscription-dev.zentral.erp.splitdns.ti-dienste.de:443`
 
 |===
 NOTE: In `Authorization:` wird das von der VAU generierte Bearer Token mit dem Pseudonym über die Telematik-ID übergeben.


### PR DESCRIPTION
Hallo,

im Rahmen der Tests für die neuen FHIR-Profile, die aktuell nur in der RU-DEV verfügbar sind, bin ich auf der Suche nach dem Subscriptions-Endpunkt darauf gestoßen dass diese hier im Dokument fehlt. Dieser pull request ändert das.

Mit besten Grüßen