### PR TITLE
Remove warning about communications deletion on $close operation

### DIFF
--- a/docs/erp_diga.adoc
+++ b/docs/erp_diga.adoc
@@ -1650,8 +1650,6 @@ NOTE: Die Verwendung des Profils GEM_ERP_PR_Communication_DiGA ist erst mit Eins
 
 NOTE: Wenn das Profil GEM_ERP_PR_Communication_Reply verwendet wird, muss ein JSON in payload.contentString angegeben werden. Die Validierung der JSON-payload wird nach folgendem Schema durchgeführt link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationReplyPayload.json[Reply JSON-Schema]. Daher muss im Feld "supplyOptionsType" verpflichtend ein Wert angegeben werden. Als default sollte "delivery" gesetzt werden. FdV's SOLLEN diesen Wert ignorieren.
 
-WARNING: Nach Aufruf der $close Operation werden alle Communications zu einem Task gelöscht.
-
 *Request*
 [cols="h,a", separator=¦]
 [%autowidth]

--- a/docs_sources/erp_diga-source.adoc
+++ b/docs_sources/erp_diga-source.adoc
@@ -493,8 +493,6 @@ NOTE: Die Verwendung des Profils GEM_ERP_PR_Communication_DiGA ist erst mit Eins
 
 NOTE: Wenn das Profil GEM_ERP_PR_Communication_Reply verwendet wird, muss ein JSON in payload.contentString angegeben werden. Die Validierung der JSON-payload wird nach folgendem Schema durchgeführt link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationReplyPayload.json[Reply JSON-Schema]. Daher muss im Feld "supplyOptionsType" verpflichtend ein Wert angegeben werden. Als default sollte "delivery" gesetzt werden. FdV's SOLLEN diesen Wert ignorieren. 
 
-WARNING: Nach Aufruf der $close Operation werden alle Communications zu einem Task gelöscht.
-
 *Request*
 [cols="h,a", separator=¦]
 [%autowidth]


### PR DESCRIPTION
Eliminate the warning that stated all communications would be deleted when the $close operation is called on a Task.