### PR TITLE
Fix script paths for terminology config table builder in dev container

### DIFF
--- a/resources/scripts/terminologyconfig-table-builder.py
+++ b/resources/scripts/terminologyconfig-table-builder.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from datetime import datetime, timedelta
 
 # Define the paths
-base_path = Path("/workspaces/api-erp/resources/configuration_terminology")
-output_path = Path("/workspaces/api-erp/resources/scripts/output_adoc")
+resources_path = Path(__file__).resolve().parent.parent
+base_path = resources_path / "configuration_terminology"
+output_path = resources_path / "scripts" / "output_adoc"
 output_file = output_path / "terminology_table.adoc"
 
 # Ensure the output directory exists


### PR DESCRIPTION
Update the script to use absolute paths for the resources when running in a development container.