### PR TITLE
Add hint about limited Task ID availability

### DIFF
--- a/docs/erp_bereitstellen.adoc
+++ b/docs/erp_bereitstellen.adoc
@@ -76,7 +76,7 @@ WARNING: Die Operation `POST /Task/$create` DARF NICHT zum Aufbau von Vorräten 
 Jeder `create`-Aufruf führt serverseitig zur Vergabe einer neuen, fortlaufenden und über lange Zeit eindeutig zu haltenden Rezept-/Task-ID.
 Nicht aktivierte bzw. verworfene Tasks „verbrauchen“ diese IDs dauerhaft und reduzieren den verfügbaren Nummernraum.
 
-NOTE: Ein `create` SOLL daher erst dann erfolgen, wenn das Primärsystem tatsächlich ein E-Rezept erzeugen und im Anschluss zeitnah mit `activate` starten will.
+NOTE: Ein `create` sollte daher erst dann erfolgen, wenn das Primärsystem tatsächlich ein E-Rezept erzeugen und im Anschluss zeitnah mit `activate` starten will.
 Insbesondere ist das Generieren des maximal möglichen Kontingents pro Formular-/Maskenöffnung oder „auf Verdacht“ zu unterlassen.
 
 Nach der qualifizierten elektronischen Signatur des Bundles wird dieses im Task ergänzt und der Workflow des E-Rezepts mit der Aktivierung des Tasks gestartet. Im Aufruf an den E-Rezept-Fachdienst muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Der E-Rezept-Fachdienst generiert beim Einstellen einen AccessCode, der fortan bei allen Zugriffen im http-Request-Header `X-AccessCode` übermittelt werden muss.

--- a/docs/erp_bereitstellen.adoc
+++ b/docs/erp_bereitstellen.adoc
@@ -72,6 +72,13 @@ Ein Leistungserbringer will mit seinem Primärsystem ein E-Rezept erzeugen. Hier
 
 NOTE: Voraussetzung für die Verwendung des E-Rezeptes für Privatversicherte ist die sichere digitale Übermittlung von Versichertenstammdaten an verordnende Leistungserbringer. Der "Online Check-in" ist das definierte digitale Verfahren, um verordnenden Leistungserbringern die Krankenversichertennummer und weitere Versichertenstammdaten einmalig (und nach Änderungen) zur Nutzung von TI-Anwendungen bereitzustellen. Die Implementierung des Verfahren ist daher erforderlich, um auch Funktionen für Privatversicherte und Workflows 200 und 209 bereitzustellen. Für die Beschreibung des Verfahrens siehe link:https://simplifier.net/guide/implementierungsleitfaden-vsdm-ersatzbescheinigung?version=current[Implementierungsleitfaden - Online Check-In]
 
+WARNING: Die Operation `POST /Task/$create` DARF NICHT zum Aufbau von Vorräten (Prefetch) oder zum „Vorbereiten“ von Rezept-Hüllen ohne konkrete Verordnungsabsicht verwendet werden.
+Jeder `create`-Aufruf führt serverseitig zur Vergabe einer neuen, fortlaufenden und über lange Zeit eindeutig zu haltenden Rezept-/Task-ID.
+Nicht aktivierte bzw. verworfene Tasks „verbrauchen“ diese IDs dauerhaft und reduzieren den verfügbaren Nummernraum.
+
+NOTE: Ein `create` SOLL daher erst dann erfolgen, wenn das Primärsystem tatsächlich ein E-Rezept erzeugen und im Anschluss zeitnah mit `activate` starten will.
+Insbesondere ist das Generieren des maximal möglichen Kontingents pro Formular-/Maskenöffnung oder „auf Verdacht“ zu unterlassen.
+
 Nach der qualifizierten elektronischen Signatur des Bundles wird dieses im Task ergänzt und der Workflow des E-Rezepts mit der Aktivierung des Tasks gestartet. Im Aufruf an den E-Rezept-Fachdienst muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Der E-Rezept-Fachdienst generiert beim Einstellen einen AccessCode, der fortan bei allen Zugriffen im http-Request-Header `X-AccessCode` übermittelt werden muss.
 
 Der Aufruf erfolgt als http-`POST`-Operation. Im Aufruf muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Im http-RequestBody MÜSSEN die Konfigurationsparameter des Workflows `flowType` und der Typ der intendierten Leistungserbringerinstitution `healthCareProviderType` enthalten sein. +

--- a/docs/erp_steuerung_durch_le.adoc
+++ b/docs/erp_steuerung_durch_le.adoc
@@ -62,7 +62,7 @@ WARNING: Auch für die Workflows 169/209 gilt: `POST /Task/$create` ist kein Mec
 Jeder `create`-Aufruf erzeugt eine neue fortlaufende und langfristig eindeutig zu haltende Rezept-/Task-ID.
 Werden Tasks ohne anschließendes Befüllen und `activate` erzeugt (z. B. Prefetch beim Öffnen einer Maske), führt dies zu dauerhaftem Verbrauch von IDs.
 
-NOTE: Das Primärsystem SOLL `create` nur im Rahmen einer konkreten Verordnung ausführen und die Erzeugung zusätzlicher Tasks ohne unmittelbare Nutzung unterlassen.
+NOTE: Das Primärsystem sollte `create` nur im Rahmen einer konkreten Verordnung ausführen und die Erzeugung zusätzlicher Tasks ohne unmittelbare Nutzung unterlassen.
 
 Der Aufruf erfolgt als http-`POST`-Operation. Im Aufruf muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Im http-RequestBody MUSS der Konfigurationsparameter des Workflows `flowType` übergeben werden.
 Der E-Rezept-Fachdienst speichert den Task unter einer generierten ID, welche im Response-Header `Location` zurückgemeldet wird und zusätzlich ist im http-ResponseBody des Task der serverseitig generierte AccessCode als Identifier enthalten.

--- a/docs/erp_steuerung_durch_le.adoc
+++ b/docs/erp_steuerung_durch_le.adoc
@@ -58,6 +58,12 @@ In den folgenden Kapiteln wird erläutert, wann und wie die Befüllung dieser At
 == Anwendungsfall Workflow 169 (209) durch Verordnenden erzeugen
 Ein Leistungserbringer will mit seinem Primärsystem ein E-Rezept für den Workflow 169 (209) erzeugen. Hierfür erstellt das Primärsystem ein FHIR-Bundle gemäß der KBV-Profilierung des E-Rezepts (siehe https://simplifier.net/erezept) mit workflowspezifischen Parametern. Für die Bereitstellung an den Versicherten wird auf dem E-Rezept-Fachdienst ein Task erstellt, dessen Identifier als Rezept-ID in das FHIR-Bundle eingebettet wird. Nach der qualifizierten elektronischen Signatur des Bundles wird dieses im Task ergänzt und der Workflow des E-Rezepts mit der Aktivierung des Tasks gestartet.
 
+WARNING: Auch für die Workflows 169/209 gilt: `POST /Task/$create` ist kein Mechanismus zur Bevorratung von Task-IDs.
+Jeder `create`-Aufruf erzeugt eine neue fortlaufende und langfristig eindeutig zu haltende Rezept-/Task-ID.
+Werden Tasks ohne anschließendes Befüllen und `activate` erzeugt (z. B. Prefetch beim Öffnen einer Maske), führt dies zu dauerhaftem Verbrauch von IDs.
+
+NOTE: Das Primärsystem SOLL `create` nur im Rahmen einer konkreten Verordnung ausführen und die Erzeugung zusätzlicher Tasks ohne unmittelbare Nutzung unterlassen.
+
 Der Aufruf erfolgt als http-`POST`-Operation. Im Aufruf muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Im http-RequestBody MUSS der Konfigurationsparameter des Workflows `flowType` übergeben werden.
 Der E-Rezept-Fachdienst speichert den Task unter einer generierten ID, welche im Response-Header `Location` zurückgemeldet wird und zusätzlich ist im http-ResponseBody des Task der serverseitig generierte AccessCode als Identifier enthalten.
 

--- a/docs_sources/erp_bereitstellen-source.adoc
+++ b/docs_sources/erp_bereitstellen-source.adoc
@@ -51,6 +51,13 @@ Ein Leistungserbringer will mit seinem Primärsystem ein E-Rezept erzeugen. Hier
 
 NOTE: Voraussetzung für die Verwendung des E-Rezeptes für Privatversicherte ist die sichere digitale Übermittlung von Versichertenstammdaten an verordnende Leistungserbringer. Der "Online Check-in" ist das definierte digitale Verfahren, um verordnenden Leistungserbringern die Krankenversichertennummer und weitere Versichertenstammdaten einmalig (und nach Änderungen) zur Nutzung von TI-Anwendungen bereitzustellen. Die Implementierung des Verfahren ist daher erforderlich, um auch Funktionen für Privatversicherte und Workflows 200 und 209 bereitzustellen. Für die Beschreibung des Verfahrens siehe link:https://simplifier.net/guide/implementierungsleitfaden-vsdm-ersatzbescheinigung?version=current[Implementierungsleitfaden - Online Check-In]
 
+WARNING: Die Operation `POST /Task/$create` DARF NICHT zum Aufbau von Vorräten (Prefetch) oder zum „Vorbereiten“ von Rezept-Hüllen ohne konkrete Verordnungsabsicht verwendet werden.
+Jeder `create`-Aufruf führt serverseitig zur Vergabe einer neuen, fortlaufenden und über lange Zeit eindeutig zu haltenden Rezept-/Task-ID.
+Nicht aktivierte bzw. verworfene Tasks „verbrauchen“ diese IDs dauerhaft und reduzieren den verfügbaren Nummernraum.
+
+NOTE: Ein `create` SOLL daher erst dann erfolgen, wenn das Primärsystem tatsächlich ein E-Rezept erzeugen und im Anschluss zeitnah mit `activate` starten will.
+Insbesondere ist das Generieren des maximal möglichen Kontingents pro Formular-/Maskenöffnung oder „auf Verdacht“ zu unterlassen.
+
 Nach der qualifizierten elektronischen Signatur des Bundles wird dieses im Task ergänzt und der Workflow des E-Rezepts mit der Aktivierung des Tasks gestartet. Im Aufruf an den E-Rezept-Fachdienst muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Der E-Rezept-Fachdienst generiert beim Einstellen einen AccessCode, der fortan bei allen Zugriffen im http-Request-Header `X-AccessCode` übermittelt werden muss.
 
 Der Aufruf erfolgt als http-`POST`-Operation. Im Aufruf muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Im http-RequestBody MÜSSEN die Konfigurationsparameter des Workflows `flowType` und der Typ der intendierten Leistungserbringerinstitution `healthCareProviderType` enthalten sein. +

--- a/docs_sources/erp_bereitstellen-source.adoc
+++ b/docs_sources/erp_bereitstellen-source.adoc
@@ -51,11 +51,11 @@ Ein Leistungserbringer will mit seinem Primärsystem ein E-Rezept erzeugen. Hier
 
 NOTE: Voraussetzung für die Verwendung des E-Rezeptes für Privatversicherte ist die sichere digitale Übermittlung von Versichertenstammdaten an verordnende Leistungserbringer. Der "Online Check-in" ist das definierte digitale Verfahren, um verordnenden Leistungserbringern die Krankenversichertennummer und weitere Versichertenstammdaten einmalig (und nach Änderungen) zur Nutzung von TI-Anwendungen bereitzustellen. Die Implementierung des Verfahren ist daher erforderlich, um auch Funktionen für Privatversicherte und Workflows 200 und 209 bereitzustellen. Für die Beschreibung des Verfahrens siehe link:https://simplifier.net/guide/implementierungsleitfaden-vsdm-ersatzbescheinigung?version=current[Implementierungsleitfaden - Online Check-In]
 
-WARNING: Die Operation `POST /Task/$create` DARF NICHT zum Aufbau von Vorräten (Prefetch) oder zum „Vorbereiten“ von Rezept-Hüllen ohne konkrete Verordnungsabsicht verwendet werden.
+WARNING: Die Operation `POST /Task/$create` ist nicht zum Aufbau von Vorräten (Prefetch) oder zum „Vorbereiten" von Rezept-Hüllen ohne konkrete Verordnungsabsicht vorgesehen.
 Jeder `create`-Aufruf führt serverseitig zur Vergabe einer neuen, fortlaufenden und über lange Zeit eindeutig zu haltenden Rezept-/Task-ID.
 Nicht aktivierte bzw. verworfene Tasks „verbrauchen“ diese IDs dauerhaft und reduzieren den verfügbaren Nummernraum.
 
-NOTE: Ein `create` SOLL daher erst dann erfolgen, wenn das Primärsystem tatsächlich ein E-Rezept erzeugen und im Anschluss zeitnah mit `activate` starten will.
+NOTE: Ein `create` sollte daher erst dann erfolgen, wenn das Primärsystem tatsächlich ein E-Rezept erzeugen und im Anschluss zeitnah mit `activate` starten will.
 Insbesondere ist das Generieren des maximal möglichen Kontingents pro Formular-/Maskenöffnung oder „auf Verdacht“ zu unterlassen.
 
 Nach der qualifizierten elektronischen Signatur des Bundles wird dieses im Task ergänzt und der Workflow des E-Rezepts mit der Aktivierung des Tasks gestartet. Im Aufruf an den E-Rezept-Fachdienst muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Der E-Rezept-Fachdienst generiert beim Einstellen einen AccessCode, der fortan bei allen Zugriffen im http-Request-Header `X-AccessCode` übermittelt werden muss.

--- a/docs_sources/erp_steuerung_durch_le-source.adoc
+++ b/docs_sources/erp_steuerung_durch_le-source.adoc
@@ -37,6 +37,12 @@ In den folgenden Kapiteln wird erläutert, wann und wie die Befüllung dieser At
 == Anwendungsfall Workflow 169 (209) durch Verordnenden erzeugen
 Ein Leistungserbringer will mit seinem Primärsystem ein E-Rezept für den Workflow 169 (209) erzeugen. Hierfür erstellt das Primärsystem ein FHIR-Bundle gemäß der KBV-Profilierung des E-Rezepts (siehe https://simplifier.net/erezept) mit workflowspezifischen Parametern. Für die Bereitstellung an den Versicherten wird auf dem E-Rezept-Fachdienst ein Task erstellt, dessen Identifier als Rezept-ID in das FHIR-Bundle eingebettet wird. Nach der qualifizierten elektronischen Signatur des Bundles wird dieses im Task ergänzt und der Workflow des E-Rezepts mit der Aktivierung des Tasks gestartet.
 
+WARNING: Auch für die Workflows 169/209 gilt: `POST /Task/$create` ist kein Mechanismus zur Bevorratung von Task-IDs.
+Jeder `create`-Aufruf erzeugt eine neue fortlaufende und langfristig eindeutig zu haltende Rezept-/Task-ID.
+Werden Tasks ohne anschließendes Befüllen und `activate` erzeugt (z. B. Prefetch beim Öffnen einer Maske), führt dies zu dauerhaftem Verbrauch von IDs.
+
+NOTE: Das Primärsystem SOLL `create` nur im Rahmen einer konkreten Verordnung ausführen und die Erzeugung zusätzlicher Tasks ohne unmittelbare Nutzung unterlassen.
+
 Der Aufruf erfolgt als http-`POST`-Operation. Im Aufruf muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Im http-RequestBody MUSS der Konfigurationsparameter des Workflows `flowType` übergeben werden.
 Der E-Rezept-Fachdienst speichert den Task unter einer generierten ID, welche im Response-Header `Location` zurückgemeldet wird und zusätzlich ist im http-ResponseBody des Task der serverseitig generierte AccessCode als Identifier enthalten.
 

--- a/docs_sources/erp_steuerung_durch_le-source.adoc
+++ b/docs_sources/erp_steuerung_durch_le-source.adoc
@@ -41,7 +41,7 @@ WARNING: Auch für die Workflows 169/209 gilt: `POST /Task/$create` ist kein Mec
 Jeder `create`-Aufruf erzeugt eine neue fortlaufende und langfristig eindeutig zu haltende Rezept-/Task-ID.
 Werden Tasks ohne anschließendes Befüllen und `activate` erzeugt (z. B. Prefetch beim Öffnen einer Maske), führt dies zu dauerhaftem Verbrauch von IDs.
 
-NOTE: Das Primärsystem SOLL `create` nur im Rahmen einer konkreten Verordnung ausführen und die Erzeugung zusätzlicher Tasks ohne unmittelbare Nutzung unterlassen.
+NOTE: Das Primärsystem sollte `create` nur im Rahmen einer konkreten Verordnung ausführen und die Erzeugung zusätzlicher Tasks ohne unmittelbare Nutzung unterlassen.
 
 Der Aufruf erfolgt als http-`POST`-Operation. Im Aufruf muss das während der Authentisierung erhaltene ACCESS_TOKEN im http-Request-Header `Authorization` übergeben werden. Im http-RequestBody MUSS der Konfigurationsparameter des Workflows `flowType` übergeben werden.
 Der E-Rezept-Fachdienst speichert den Task unter einer generierten ID, welche im Response-Header `Location` zurückgemeldet wird und zusätzlich ist im http-ResponseBody des Task der serverseitig generierte AccessCode als Identifier enthalten.


### PR DESCRIPTION
Dieser PR fügt wichtige Warnungen und Hinweise zur POST /Task/$create Operation in die E-Rezept API-Dokumentation ein.