### PR TITLE
Add note for DiGA prescription printing requirements

### DIFF
--- a/docs/erp_diga.adoc
+++ b/docs/erp_diga.adoc
@@ -203,6 +203,8 @@ Nach Bereitstellung des Tasks für die DiGA-Verordnung muss das Primärsystem de
 
 Der Datensatz ist analog zum Arzneimittelkontext qualifiziert zu signieren und dann via POST am E-Rezept-Fachdienst einzustellen.
 
+NOTE: Um die Einlösung einer elektronischen DiGA-Verordnung (Flowtype 162) sicherzustellen, ist dem Patienten ein Ausdruck auszuhändigen, ausgenommen der Patient lehnt einen Ausdruck ab, da er bspw. ein E-Rezept-Frontend des Versicherten der Krankenkasse oder der gematik nutzt.
+
 .Beispiel für ein DiGA-Bundle (Klicken zum Ausklappen)
 [%collapsible]
 

--- a/docs_sources/erp_diga-source.adoc
+++ b/docs_sources/erp_diga-source.adoc
@@ -141,6 +141,8 @@ Nach Bereitstellung des Tasks für die DiGA-Verordnung muss das Primärsystem de
 
 Der Datensatz ist analog zum Arzneimittelkontext qualifiziert zu signieren und dann via POST am E-Rezept-Fachdienst einzustellen.
 
+NOTE: Um die Einlösung einer elektronischen DiGA-Verordnung (Flowtype 162) sicherzustellen, ist dem Patienten ein Ausdruck auszuhändigen, ausgenommen der Patient lehnt einen Ausdruck ab, da er bspw. ein E-Rezept-Frontend des Versicherten der Krankenkasse oder der gematik nutzt.
+
 .Beispiel für ein DiGA-Bundle (Klicken zum Ausklappen)
 [%collapsible]
 


### PR DESCRIPTION
Add a note clarifying the necessity of providing a printout for patients when redeeming an electronic DiGA prescription, unless they opt out due to using specific e-prescription frontends.

#TMD-3053