### PR TITLE
Update API documentation for available channels endpoint

### DIFF
--- a/docs/erp_push_notifications.adoc
+++ b/docs/erp_push_notifications.adoc
@@ -338,7 +338,7 @@ Zuviele Anfragen pro Zeiteinheit durch diesen Nutzer.
 Der E-Rezept-Fachdienst unterstützt das optionale Feature "Channels". Die spezifischen API-Endpunkte sind hier beschrieben.
 
 === Verfügbare Channels
-Ruft alle verfügbaren Channels für den authentifizierten Nutzer ab.
+Ruft alle verfügbaren Channels für den authentifizierten Nutzer inklusive des Standardkonfigurationsstatus ab. Dieser Endpoint kann verwendet werden, um die Channels eines Nutzers abzurufen, der keine aktiven Pusher oder Geräte hat.
 
 ==== Request
 [cols="h,a", width="100%", separator=¦]

--- a/resources/openapi/erp_fd_push_notifications.yaml
+++ b/resources/openapi/erp_fd_push_notifications.yaml
@@ -229,7 +229,7 @@ paths:
   /channels/v1:
     get:
       summary: Gets the available channels
-      description: Gets all available channels for the authenticated user along with the default configuration state. This endpoint can be used to retrieve the channels for a user that has no active pushers or devices.
+      description: Gets all available channels for the authenticated user along with the default configuration state. This endpoint can be used to retrieve the channels for a user that has no active pushers or devices. The status returned for each channel is the default status for new pushers and devices; in this case, it is always "disabled". If a user has active pushers or devices, the endpoint /channels/v1/{pushkey} should be used to retrieve the actual channel configuration for the specific device.
       operationId: getChannels
       x-allowed-requester:
           - "FdV"
@@ -242,7 +242,7 @@ paths:
           description: ACCESS_TOKEN, ausgestellt vom IDP
       responses:
         "200":
-          description: The channels for this user.
+          description: The channels available for this user.
           content:
             application/json:
               schema:

--- a/resources/openapi/erp_fd_push_notifications.yaml
+++ b/resources/openapi/erp_fd_push_notifications.yaml
@@ -229,7 +229,7 @@ paths:
   /channels/v1:
     get:
       summary: Gets the available channels
-      description: Gets all available channels for the authenticated user.
+      description: Gets all available channels for the authenticated user along with the default configuration state. This endpoint can be used to retrieve the channels for a user that has no active pushers or devices.
       operationId: getChannels
       x-allowed-requester:
           - "FdV"


### PR DESCRIPTION
Enhance the description of the available channels endpoint to clarify the inclusion of default configuration states and the status for new pushers and devices. This improves understanding.