### PR TITLE
Update error response examples in OpenAPI documentation for push notifications

### DIFF
--- a/docs/erp_push_notifications.adoc
+++ b/docs/erp_push_notifications.adoc
@@ -110,8 +110,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "malformedRequest",
+  "errorDetail": "Ungültiger http-Request"
 }
 ----
 ====
@@ -121,8 +121,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidAccessToken",
+  "errorDetail": "Ungültiges/Abgelaufenes AccessToken"
 }
 ----
 ====
@@ -132,8 +132,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidOid",
+  "errorDetail": "Unzulässige fachliche Rolle"
 }
 ----
 ====
@@ -143,8 +143,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "notAcceptable",
+  "errorDetail": "Angefragter Mime-Type im Accept-Header kann nicht bedient werden"
 }
 ----
 ====
@@ -154,8 +154,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "timeout",
+  "errorDetail": "Timeout"
 }
 ----
 ====
@@ -165,8 +165,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "rateLimitExceeded",
+  "errorDetail": "Zuviele Anfragen pro Zeiteinheit durch diesen Nutzer"
 }
 ----
 ====
@@ -248,8 +248,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "malformedRequest",
+  "errorDetail": "Ungültiger http-Request"
 }
 ----
 ====
@@ -259,8 +259,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidAccessToken",
+  "errorDetail": "Ungültiges/Abgelaufenes AccessToken"
 }
 ----
 ====
@@ -270,8 +270,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidOid",
+  "errorDetail": "Unzulässige fachliche Rolle"
 }
 ----
 ====
@@ -281,8 +281,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "notAcceptable",
+  "errorDetail": "Angefragter Mime-Type im Accept-Header kann nicht bedient werden"
 }
 ----
 ====
@@ -292,8 +292,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "timeout",
+  "errorDetail": "Timeout"
 }
 ----
 ====
@@ -303,8 +303,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "rateLimitExceeded",
+  "errorDetail": "Zuviele Anfragen pro Zeiteinheit durch diesen Nutzer"
 }
 ----
 ====
@@ -385,8 +385,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "malformedRequest",
+  "errorDetail": "Ungültiger http-Request"
 }
 ----
 ====
@@ -396,8 +396,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidAccessToken",
+  "errorDetail": "Ungültiges/Abgelaufenes AccessToken"
 }
 ----
 ====
@@ -407,8 +407,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidOid",
+  "errorDetail": "Unzulässige fachliche Rolle"
 }
 ----
 ====
@@ -418,8 +418,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "notAcceptable",
+  "errorDetail": "Angefragter Mime-Type im Accept-Header kann nicht bedient werden"
 }
 ----
 ====
@@ -429,8 +429,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "timeout",
+  "errorDetail": "Timeout"
 }
 ----
 ====
@@ -440,8 +440,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "rateLimitExceeded",
+  "errorDetail": "Zuviele Anfragen pro Zeiteinheit durch diesen Nutzer"
 }
 ----
 ====
@@ -449,7 +449,7 @@ No request body.
 2+¦Response Codes
 
 ¦200 ¦ Success +
-The channels for this user.
+The channels available for this user.
 
 ¦400 ¦ Client Error +
 Ungültiger http-Request.
@@ -519,8 +519,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "malformedRequest",
+  "errorDetail": "Ungültiger http-Request"
 }
 ----
 ====
@@ -530,8 +530,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidAccessToken",
+  "errorDetail": "Ungültiges/Abgelaufenes AccessToken"
 }
 ----
 ====
@@ -541,8 +541,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidOid",
+  "errorDetail": "Unzulässige fachliche Rolle"
 }
 ----
 ====
@@ -552,8 +552,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "notAcceptable",
+  "errorDetail": "Angefragter Mime-Type im Accept-Header kann nicht bedient werden"
 }
 ----
 ====
@@ -563,8 +563,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "timeout",
+  "errorDetail": "Timeout"
 }
 ----
 ====
@@ -574,8 +574,8 @@ No request body.
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "rateLimitExceeded",
+  "errorDetail": "Zuviele Anfragen pro Zeiteinheit durch diesen Nutzer"
 }
 ----
 ====
@@ -660,8 +660,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "malformedRequest",
+  "errorDetail": "Ungültiger http-Request"
 }
 ----
 ====
@@ -671,8 +671,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidAccessToken",
+  "errorDetail": "Ungültiges/Abgelaufenes AccessToken"
 }
 ----
 ====
@@ -682,8 +682,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "invalidOid",
+  "errorDetail": "Unzulässige fachliche Rolle"
 }
 ----
 ====
@@ -693,8 +693,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "notAcceptable",
+  "errorDetail": "Angefragter Mime-Type im Accept-Header kann nicht bedient werden"
 }
 ----
 ====
@@ -704,8 +704,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "timeout",
+  "errorDetail": "Timeout"
 }
 ----
 ====
@@ -715,8 +715,8 @@ Authorization: Bearer <JWT> (string, required)
 [source,json]
 ----
 {
-  "errorCode": "UNKNOWN",
-  "errorDetail": "An unknown error occurred"
+  "errorCode": "rateLimitExceeded",
+  "errorDetail": "Zuviele Anfragen pro Zeiteinheit durch diesen Nutzer"
 }
 ----
 ====

--- a/docs/erp_push_notifications.adoc
+++ b/docs/erp_push_notifications.adoc
@@ -137,6 +137,17 @@ Authorization: Bearer <JWT> (string, required)
 }
 ----
 ====
+.Response Body (405) (Klicken zum Ausklappen)
+[%collapsible]
+====
+[source,json]
+----
+{
+  "errorCode": "methodNotAllowed",
+  "errorDetail": "Die verwendete HTTP-Methode ist für diese Ressource nicht zulässig"
+}
+----
+====
 .Response Body (406) (Klicken zum Ausklappen)
 [%collapsible]
 ====
@@ -184,6 +195,9 @@ Ungültiges/Abgelaufenes AccessToken.
 
 ¦403 ¦ Client Error +
 Unzulässige fachliche Rolle.
+
+¦405 ¦ Client Error +
+Methode nicht erlaubt.
 
 ¦406 ¦ Client Error +
 Angefragter Mime-Type im Accept-Header kann nicht bedient werden.
@@ -275,6 +289,17 @@ No request body.
 }
 ----
 ====
+.Response Body (405) (Klicken zum Ausklappen)
+[%collapsible]
+====
+[source,json]
+----
+{
+  "errorCode": "methodNotAllowed",
+  "errorDetail": "Die verwendete HTTP-Methode ist für diese Ressource nicht zulässig"
+}
+----
+====
 .Response Body (406) (Klicken zum Ausklappen)
 [%collapsible]
 ====
@@ -322,6 +347,9 @@ Ungültiges/Abgelaufenes AccessToken.
 
 ¦403 ¦ Client Error +
 Unzulässige fachliche Rolle.
+
+¦405 ¦ Client Error +
+Methode nicht erlaubt.
 
 ¦406 ¦ Client Error +
 Angefragter Mime-Type im Accept-Header kann nicht bedient werden.
@@ -412,6 +440,17 @@ No request body.
 }
 ----
 ====
+.Response Body (405) (Klicken zum Ausklappen)
+[%collapsible]
+====
+[source,json]
+----
+{
+  "errorCode": "methodNotAllowed",
+  "errorDetail": "Die verwendete HTTP-Methode ist für diese Ressource nicht zulässig"
+}
+----
+====
 .Response Body (406) (Klicken zum Ausklappen)
 [%collapsible]
 ====
@@ -459,6 +498,9 @@ Ungültiges/Abgelaufenes AccessToken.
 
 ¦403 ¦ Client Error +
 Unzulässige fachliche Rolle.
+
+¦405 ¦ Client Error +
+Methode nicht erlaubt.
 
 ¦406 ¦ Client Error +
 Angefragter Mime-Type im Accept-Header kann nicht bedient werden.
@@ -546,6 +588,17 @@ No request body.
 }
 ----
 ====
+.Response Body (405) (Klicken zum Ausklappen)
+[%collapsible]
+====
+[source,json]
+----
+{
+  "errorCode": "methodNotAllowed",
+  "errorDetail": "Die verwendete HTTP-Methode ist für diese Ressource nicht zulässig"
+}
+----
+====
 .Response Body (406) (Klicken zum Ausklappen)
 [%collapsible]
 ====
@@ -593,6 +646,9 @@ Ungültiges/Abgelaufenes AccessToken.
 
 ¦403 ¦ Client Error +
 Unzulässige fachliche Rolle.
+
+¦405 ¦ Client Error +
+Methode nicht erlaubt.
 
 ¦406 ¦ Client Error +
 Angefragter Mime-Type im Accept-Header kann nicht bedient werden.
@@ -687,6 +743,17 @@ Authorization: Bearer <JWT> (string, required)
 }
 ----
 ====
+.Response Body (405) (Klicken zum Ausklappen)
+[%collapsible]
+====
+[source,json]
+----
+{
+  "errorCode": "methodNotAllowed",
+  "errorDetail": "Die verwendete HTTP-Methode ist für diese Ressource nicht zulässig"
+}
+----
+====
 .Response Body (406) (Klicken zum Ausklappen)
 [%collapsible]
 ====
@@ -734,6 +801,9 @@ Ungültiges/Abgelaufenes AccessToken.
 
 ¦403 ¦ Client Error +
 Unzulässige fachliche Rolle.
+
+¦405 ¦ Client Error +
+Methode nicht erlaubt.
 
 ¦406 ¦ Client Error +
 Angefragter Mime-Type im Accept-Header kann nicht bedient werden.

--- a/resources/openapi/erp_fd_push_notifications.yaml
+++ b/resources/openapi/erp_fd_push_notifications.yaml
@@ -16,7 +16,7 @@
 openapi: 3.0.3
 info:
   title: E-Rezept-Fachdienst API for Push Notifications
-  version: 1.1.2
+  version: 1.2.0
   description: API Endpoints for managing pushers, the channel configuration and retrieving previously sent notifications.
   license:
     name: Apache 2.0

--- a/resources/openapi/erp_fd_push_notifications.yaml
+++ b/resources/openapi/erp_fd_push_notifications.yaml
@@ -52,6 +52,8 @@ paths:
           $ref: "#/components/responses/ErrorResponse401"
         "403":
           $ref: "#/components/responses/ErrorResponse403"
+        "405":
+          $ref: "#/components/responses/ErrorResponse405"
         "406":
           $ref: "#/components/responses/ErrorResponse406"
         "408":
@@ -111,6 +113,8 @@ paths:
           $ref: "#/components/responses/ErrorResponse401"
         "403":
           $ref: "#/components/responses/ErrorResponse403"
+        "405":
+          $ref: "#/components/responses/ErrorResponse405"
         "406":
           $ref: "#/components/responses/ErrorResponse406"
         "408":
@@ -158,6 +162,8 @@ paths:
           $ref: "#/components/responses/ErrorResponse401"
         "403":
           $ref: "#/components/responses/ErrorResponse403"
+        "405":
+          $ref: "#/components/responses/ErrorResponse405"
         "406":
           $ref: "#/components/responses/ErrorResponse406"
         "408":
@@ -218,6 +224,8 @@ paths:
           $ref: "#/components/responses/ErrorResponse401"
         "403":
           $ref: "#/components/responses/ErrorResponse403"
+        "405":
+          $ref: "#/components/responses/ErrorResponse405"
         "406":
           $ref: "#/components/responses/ErrorResponse406"
         "408":
@@ -256,6 +264,8 @@ paths:
           $ref: "#/components/responses/ErrorResponse401"
         "403":
           $ref: "#/components/responses/ErrorResponse403"
+        "405":
+          $ref: "#/components/responses/ErrorResponse405"
         "406":
           $ref: "#/components/responses/ErrorResponse406"
         "408":

--- a/resources/openapi/erp_fd_push_notifications.yaml
+++ b/resources/openapi/erp_fd_push_notifications.yaml
@@ -281,36 +281,63 @@ components:
       description: Ungültiger http-Request.
       content:
         application/json:
+          example:
+            errorCode: malformedRequest
+            errorDetail: "Ungültiger http-Request"
           schema:
             $ref: "https://raw.githubusercontent.com/gematik/gem-push-notifications-concept/refs/tags/1.2.0/docs_sources/definitions/error.yaml"
     ErrorResponse401:
       description: Ungültiges/Abgelaufenes AccessToken.
       content:
         application/json:
+          example:
+            errorCode: invalidAccessToken
+            errorDetail: "Ungültiges/Abgelaufenes AccessToken"
           schema:
             $ref: "https://raw.githubusercontent.com/gematik/gem-push-notifications-concept/refs/tags/1.2.0/docs_sources/definitions/error.yaml"
     ErrorResponse403:
       description: Unzulässige fachliche Rolle.
       content:
         application/json:
+          example:
+            errorCode: invalidOid
+            errorDetail: "Unzulässige fachliche Rolle"
+          schema:
+            $ref: "https://raw.githubusercontent.com/gematik/gem-push-notifications-concept/refs/tags/1.2.0/docs_sources/definitions/error.yaml"
+    ErrorResponse405:
+      description: Methode nicht erlaubt.
+      content:
+        application/json:
+          example:
+            errorCode: methodNotAllowed
+            errorDetail: "Die verwendete HTTP-Methode ist für diese Ressource nicht zulässig"
           schema:
             $ref: "https://raw.githubusercontent.com/gematik/gem-push-notifications-concept/refs/tags/1.2.0/docs_sources/definitions/error.yaml"
     ErrorResponse406:
       description: Angefragter Mime-Type im Accept-Header kann nicht bedient werden.
       content:
         application/json:
+          example:
+            errorCode: notAcceptable
+            errorDetail: "Angefragter Mime-Type im Accept-Header kann nicht bedient werden"
           schema:
             $ref: "https://raw.githubusercontent.com/gematik/gem-push-notifications-concept/refs/tags/1.2.0/docs_sources/definitions/error.yaml"
     ErrorResponse408:
       description: Timeout.
       content:
         application/json:
+          example:
+            errorCode: timeout
+            errorDetail: "Timeout"  
           schema:
             $ref: "https://raw.githubusercontent.com/gematik/gem-push-notifications-concept/refs/tags/1.2.0/docs_sources/definitions/error.yaml"
     ErrorResponse429:
       description: Zuviele Anfragen pro Zeiteinheit durch diesen Nutzer.
       content:
         application/json:
+          example:
+            errorCode: rateLimitExceeded
+            errorDetail: "Zuviele Anfragen pro Zeiteinheit durch diesen Nutzer"
           schema:
             $ref: "https://raw.githubusercontent.com/gematik/gem-push-notifications-concept/refs/tags/1.2.0/docs_sources/definitions/error.yaml"
 security:


### PR DESCRIPTION
Enhance the OpenAPI documentation by updating error response examples for push notifications. This includes specific error codes and their corresponding messages in German, improving clarity for developers integrating with the API.