### PR TITLE
Add note regarding AVS requirements for Communication Version 3

### DIFF
--- a/docs/erp_communication_change_20261001.adoc
+++ b/docs/erp_communication_change_20261001.adoc
@@ -26,7 +26,9 @@ toc::[]
 
 == Versionsübergabegänge
 
-Ab dem 01.10.2026 unterstützt der E-Rezept-Fachdienst Version 3 des Payloads der Communication-Ressource. Da es derzeit keine Pflicht gibt, können auch PayLoads der Version 1 weiterhin übermittelt werden. Daher müssen sowohl die FdVs als auch die AVSe weiterhin Version 1 unterstützen, um die Kompatibilität mit verschiedenen Systemen sicherzustellen. Es kann sein, dass einige Systeme nicht sofort auf Version 3 umstellen können. Daher ist es wichtig, beide Versionen zu unterstützen, um einen reibungslosen Übergang zu gewährleisten.
+Ab dem 01.10.2026 unterstützt der E-Rezept-Fachdienst Version 3 des Payloads der Communication-Ressource. Da es derzeit keine Pflicht gibt, können auch PayLoads der Version 1 weiterhin übermittelt werden. Daher müssen sowohl die FdVs als auch die AVSe weiterhin trotzdem Version 1 unterstützen, um die Kompatibilität mit verschiedenen Systemen sicherzustellen. Es kann sein, dass einige Systeme nicht sofort auf Version 3 umstellen können. Daher ist es wichtig, beide Versionen zu unterstützen, um einen reibungslosen Übergang zu gewährleisten.
+
+IMPORTANT: Das AVS muss ab dem 01.10.2026 zumindest Version 3 lesen können, darf jedoch weiterhin mit Version 1 antworten.
 
 Das AVS antworte, wenn es beide Versionen unterstützt, mit der Version, die in der Anfrage übermittelt wurde.
 

--- a/docs_sources/erp_communication_change_20261001-source.adoc
+++ b/docs_sources/erp_communication_change_20261001-source.adoc
@@ -5,7 +5,9 @@ toc::[]
 
 == Versionsübergabegänge
 
-Ab dem 01.10.2026 unterstützt der E-Rezept-Fachdienst Version 3 des Payloads der Communication-Ressource. Da es derzeit keine Pflicht gibt, können auch PayLoads der Version 1 weiterhin übermittelt werden. Daher müssen sowohl die FdVs als auch die AVSe weiterhin Version 1 unterstützen, um die Kompatibilität mit verschiedenen Systemen sicherzustellen. Es kann sein, dass einige Systeme nicht sofort auf Version 3 umstellen können. Daher ist es wichtig, beide Versionen zu unterstützen, um einen reibungslosen Übergang zu gewährleisten.
+Ab dem 01.10.2026 unterstützt der E-Rezept-Fachdienst Version 3 des Payloads der Communication-Ressource. Da es derzeit keine Pflicht gibt, können auch PayLoads der Version 1 weiterhin übermittelt werden. Daher müssen sowohl die FdVs als auch die AVSe weiterhin trotzdem Version 1 unterstützen, um die Kompatibilität mit verschiedenen Systemen sicherzustellen. Es kann sein, dass einige Systeme nicht sofort auf Version 3 umstellen können. Daher ist es wichtig, beide Versionen zu unterstützen, um einen reibungslosen Übergang zu gewährleisten.
+
+IMPORTANT: Das AVS muss ab dem 01.10.2026 zumindest Version 3 lesen können, darf jedoch weiterhin mit Version 1 antworten.
 
 Das AVS antworte, wenn es beide Versionen unterstützt, mit der Version, die in der Anfrage übermittelt wurde.
 


### PR DESCRIPTION
Add a note stating that AVS need to at least be able to read Communication v3, but that they are allowed to continue to answer with v1