### PR TITLE
Fix schema links for CommunicationDispReqPayload and CommunicationReplyPayload

### DIFF
--- a/docs/erp_communication_change_20261001.adoc
+++ b/docs/erp_communication_change_20261001.adoc
@@ -56,7 +56,7 @@ Eine Übersicht der Unterschiede zwischen v1 und v3 ist hier zu finden:
 | v3
 | Hinweise
 
-| link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationDispReqPayload.json[JSON-Schema]
+| link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationDispReqPayloadV1.json[JSON-Schema]
 | link:https://github.com/gematik/interactive-api-erp/blob/main/erp-fd-communications/CommunicationDispReqPayload.json[JSON-Schema]
 |
 
@@ -134,7 +134,7 @@ v3: 3-100 Stellen (Beinhaltet nur Straße und Hausnummer)
 | v3
 | Hinweise
 
-| link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationReplyPayload.json[JSON-Schema]
+| link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationReplyPayloadV1.json[JSON-Schema]
 | link:https://github.com/gematik/interactive-api-erp/blob/main/erp-fd-communications/CommunicationReplyPayload.json[JSON-Schema]
 |
 

--- a/docs_sources/erp_communication_change_20261001-source.adoc
+++ b/docs_sources/erp_communication_change_20261001-source.adoc
@@ -35,7 +35,7 @@ Eine Übersicht der Unterschiede zwischen v1 und v3 ist hier zu finden:
 | v3
 | Hinweise
 
-| link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationDispReqPayload.json[JSON-Schema]
+| link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationDispReqPayloadV1.json[JSON-Schema]
 | link:https://github.com/gematik/interactive-api-erp/blob/main/erp-fd-communications/CommunicationDispReqPayload.json[JSON-Schema]
 |
 
@@ -113,7 +113,7 @@ v3: 3-100 Stellen (Beinhaltet nur Straße und Hausnummer)
 | v3
 | Hinweise
 
-| link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationReplyPayload.json[JSON-Schema]
+| link:https://github.com/eRP-FD/erp-processing-context/blob/master/resources/production/schema/shared/json/CommunicationReplyPayloadV1.json[JSON-Schema]
 | link:https://github.com/gematik/interactive-api-erp/blob/main/erp-fd-communications/CommunicationReplyPayload.json[JSON-Schema]
 |
 


### PR DESCRIPTION
Update the links for the v1 JSON schemas of CommunicationDispReqPayload and CommunicationReplyPayload to point to the correct resources.